### PR TITLE
Complete Readarr module integration

### DIFF
--- a/zagreus/lib/modules/readarr/core/api/api.dart
+++ b/zagreus/lib/modules/readarr/core/api/api.dart
@@ -115,4 +115,605 @@ class ReadarrAPI {
       return Future.error(error);
     }
   }
+
+  Future<List<String>> getAllAuthorIDs() async {
+    try {
+      Response response = await _dio.get('author');
+      List<String> _entries = [];
+      for (var entry in response.data) {
+        _entries.add(entry['foreignAuthorId'] ?? '');
+      }
+      return _entries;
+    } on DioException catch (error, stack) {
+      logError('Failed to fetch author IDs', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to fetch author IDs', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> refreshAuthor(int authorID) async {
+    try {
+      await _dio.post(
+        'command',
+        data: json.encode({
+          'name': 'RefreshAuthor',
+          'authorId': authorID,
+        }),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError('Failed to refresh author ($authorID)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to refresh author ($authorID)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<ReadarrCatalogueData> getAuthor(int? authorID) async {
+    try {
+      Map<int?, ReadarrQualityProfile> _qualities =
+          await getQualityProfiles();
+      Map<int?, ReadarrMetadataProfile> _metadatas =
+          await getMetadataProfiles();
+      Response response = await _dio.get('author/$authorID');
+      return ReadarrCatalogueData(
+        title: response.data['authorName'] ?? 'Unknown Author',
+        sortTitle: response.data['sortName'] ?? 'Unknown Author',
+        overview: response.data['overview'] ?? 'No Summary Available',
+        authorType: response.data['authorType'] ?? 'Unknown Author Type',
+        path: response.data['path'] ?? 'Unknown Path',
+        authorID: response.data['id'] ?? 0,
+        added: response.data['added'] ?? '',
+        monitored: response.data['monitored'] ?? false,
+        statistics: response.data['statistics'] ?? {},
+        qualityProfile: response.data['qualityProfileId'] ?? 0,
+        metadataProfile: response.data['metadataProfileId'] ?? 0,
+        quality: response.data['qualityProfileId'] != null
+            ? _qualities[response.data['qualityProfileId']]?.name ??
+                'Unknown Quality Profile'
+            : '',
+        metadata: response.data['metadataProfileId'] != null
+            ? _metadatas[response.data['metadataProfileId']]?.name ??
+                'Unknown Metadata Profile'
+            : '',
+        genres: response.data['genres'] ?? [],
+        links: response.data['links'] ?? [],
+        foreignAuthorID: response.data['foreignAuthorId'] ?? '',
+        sizeOnDisk: response.data['statistics'] != null
+            ? response.data['statistics']['sizeOnDisk'] ?? 0
+            : 0,
+      );
+    } on DioException catch (error, stack) {
+      logError('Failed to fetch author ($authorID)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to fetch author ($authorID)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> removeAuthor(int authorID,
+      {bool deleteFiles = false, bool addImportExclusion = false}) async {
+    try {
+      await _dio.delete(
+        'author/$authorID',
+        queryParameters: {
+          'deleteFiles': deleteFiles,
+          'addImportExclusion': addImportExclusion,
+        },
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError('Failed to remove author ($authorID)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to remove author ($authorID)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> editAuthor(
+      int authorID,
+      ReadarrQualityProfile qualityProfile,
+      ReadarrMetadataProfile metadataProfile,
+      String? path,
+      bool? monitored) async {
+    try {
+      Response response = await _dio.get('author/$authorID');
+      Map author = response.data;
+      author['monitored'] = monitored;
+      author['path'] = path;
+      author['profileId'] = qualityProfile.id;
+      author['qualityProfileId'] = qualityProfile.id;
+      author['metadataProfileId'] = metadataProfile.id;
+      response = await _dio.put(
+        'author',
+        data: json.encode(author),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError('Failed to edit author ($authorID)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to edit author ($authorID)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<List<ReadarrBookData>> getBooksForAuthor(int authorID) async {
+    try {
+      Response response = await _dio.get('book', queryParameters: {
+        'authorId': authorID,
+      });
+      List<ReadarrBookData> entries = [];
+      for (var entry in response.data) {
+        entries.add(ReadarrBookData(
+          bookID: entry['id'] ?? -1,
+          title: entry['title'] ?? 'Unknown Book Title',
+          monitored: entry['monitored'] ?? false,
+          releaseDate: entry['releaseDate'] ?? '',
+          editionCount: entry['editions'] != null
+              ? (entry['editions'] as List).length
+              : 0,
+          grabbed: entry['grabbed'] ?? false,
+          authorID: authorID,
+        ));
+      }
+      entries.sort((a, b) {
+        if (a.releaseDateObject == null) return 1;
+        if (b.releaseDateObject == null) return -1;
+        return b.releaseDateObject!.compareTo(a.releaseDateObject!);
+      });
+      return entries;
+    } on DioException catch (error, stack) {
+      logError('Failed to fetch books for author ($authorID)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to fetch books for author ($authorID)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<ReadarrBookData> getBook(int bookID) async {
+    try {
+      Response response = await _dio.get('book/$bookID');
+      return ReadarrBookData(
+        bookID: response.data['id'] ?? -1,
+        title: response.data['title'] ?? 'Unknown Book Title',
+        monitored: response.data['monitored'] ?? false,
+        releaseDate: response.data['releaseDate'] ?? '',
+        editionCount: response.data['editions'] != null
+            ? (response.data['editions'] as List).length
+            : 0,
+        grabbed: response.data['grabbed'] ?? false,
+        authorID: response.data['authorId'],
+      );
+    } on DioException catch (error, stack) {
+      logError('Failed to fetch book ($bookID)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to fetch book ($bookID)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<List<ReadarrRootFolder>> getRootFolders() async {
+    try {
+      Response response = await _dio.get('rootfolder');
+      List<ReadarrRootFolder> _entries = [];
+      for (var entry in response.data) {
+        _entries.add(ReadarrRootFolder(
+          id: entry['id'] ?? -1,
+          path: entry['path'] ?? 'Unknown Root Folder',
+          freeSpace: entry['freeSpace'] ?? 0,
+        ));
+      }
+      return _entries;
+    } on DioException catch (error, stack) {
+      logError('Failed to fetch root folders', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to fetch root folders', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<List<ReadarrHistoryData>> getHistory(
+      {String sortKey = 'date',
+      String sortDir = 'descending',
+      int pageSize = 250}) async {
+    try {
+      Response response = await _dio.get('history', queryParameters: {
+        'sortKey': sortKey,
+        'pageSize': pageSize,
+        'sortDirection': sortDir,
+      });
+      List<ReadarrHistoryData> _entries = [];
+      for (var entry in response.data['records']) {
+        switch (entry['eventType']) {
+          case 'grabbed':
+            {
+              _entries.add(ReadarrHistoryDataGrabbed(
+                title: entry['sourceTitle'] ?? 'Unknown Title',
+                timestamp: entry['date'] ?? '',
+                indexer: entry['data']['indexer'] ?? 'Unknown Indexer',
+                authorID: entry['authorId'] ?? -1,
+                bookID: entry['bookId'] ?? -1,
+              ));
+              break;
+            }
+          case 'bookFileImported':
+            {
+              _entries.add(ReadarrHistoryDataBookFileImported(
+                title: entry['sourceTitle'] ?? 'Unknown Title',
+                timestamp: entry['date'] ?? '',
+                quality:
+                    entry['quality']['quality']['name'] ?? 'Unknown Quality',
+                authorID: entry['authorId'] ?? -1,
+                bookID: entry['bookId'] ?? -1,
+              ));
+              break;
+            }
+          case 'bookImportIncomplete':
+            {
+              _entries.add(ReadarrHistoryDataBookImportIncomplete(
+                title: entry['sourceTitle'] ?? 'Unknown Title',
+                timestamp: entry['date'] ?? '',
+                authorID: entry['authorId'] ?? -1,
+                bookID: entry['bookId'] ?? -1,
+              ));
+              break;
+            }
+          case 'downloadImported':
+            {
+              _entries.add(ReadarrHistoryDataDownloadImported(
+                title: entry['sourceTitle'] ?? 'Unknown Title',
+                timestamp: entry['date'] ?? '',
+                quality:
+                    entry['quality']['quality']['name'] ?? 'Unknown Quality',
+                authorID: entry['authorId'] ?? -1,
+                bookID: entry['bookId'] ?? -1,
+              ));
+              break;
+            }
+          case 'bookFileDeleted':
+            {
+              _entries.add(ReadarrHistoryDataBookFileDeleted(
+                title: entry['sourceTitle'] ?? 'Unknown Title',
+                timestamp: entry['date'] ?? '',
+                reason: entry['data']['reason'] ?? 'Unknown Reason',
+                authorID: entry['authorId'] ?? -1,
+                bookID: entry['bookId'] ?? -1,
+              ));
+              break;
+            }
+          case 'bookFileRenamed':
+            {
+              _entries.add(ReadarrHistoryDataBookFileRenamed(
+                title: entry['sourceTitle'] ?? 'Unknown Title',
+                timestamp: entry['date'] ?? '',
+                authorID: entry['authorId'] ?? -1,
+                bookID: entry['bookId'] ?? -1,
+              ));
+              break;
+            }
+          case 'bookFileRetagged':
+            {
+              _entries.add(ReadarrHistoryDataBookFileRetagged(
+                title: entry['sourceTitle'] ?? 'Unknown Title',
+                timestamp: entry['date'] ?? '',
+                authorID: entry['authorId'] ?? -1,
+                bookID: entry['bookId'] ?? -1,
+              ));
+              break;
+            }
+          default:
+            {
+              _entries.add(ReadarrHistoryDataGeneric(
+                title: entry['sourceTitle'] ?? 'Unknown Title',
+                timestamp: entry['date'] ?? '',
+                eventType: entry['eventType'] ?? 'Unknown Event Type',
+                authorID: entry['authorId'] ?? -1,
+                bookID: entry['bookId'] ?? -1,
+              ));
+              break;
+            }
+        }
+      }
+      return _entries;
+    } on DioException catch (error, stack) {
+      logError('Failed to fetch history', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to fetch history', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<List<ReadarrMissingData>> getMissing(
+      {int pageSize = 250,
+      String sortDir = 'descending',
+      String sortKey = 'releaseDate',
+      bool monitored = true}) async {
+    try {
+      Response response = await _dio.get('wanted/missing', queryParameters: {
+        'pageSize': pageSize,
+        'sortDirection': sortDir,
+        'sortKey': sortKey,
+        'monitored': monitored,
+      });
+      List<ReadarrMissingData> entries = [];
+      for (var entry in response.data['records']) {
+        entries.add(ReadarrMissingData(
+          title: entry['title'] ?? 'Unknown Title',
+          authorTitle: entry['author']['authorName'] ?? 'Unknown Author',
+          authorID: entry['authorId'] ?? -1,
+          bookID: entry['id'] ?? -1,
+          releaseDate: entry['releaseDate'] ?? '',
+          monitored: entry['monitored'] ?? false,
+        ));
+      }
+      return entries;
+    } on DioException catch (error, stack) {
+      logError('Failed to fetch missing books', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to fetch missing books', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> searchBooks(List<int> books) async {
+    try {
+      await _dio.post(
+        'command',
+        data: json.encode({
+          'name': 'BookSearch',
+          'bookIds': books,
+        }),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError('Failed to search for books (${books.toString()})', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to search for books (${books.toString()})', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> searchAllMissing() async {
+    try {
+      await _dio.post(
+        'command',
+        data: json.encode({
+          'name': 'MissingBookSearch',
+        }),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError('Failed to search for all missing books', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to search for all missing books', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> updateLibrary() async {
+    try {
+      await _dio.post(
+        'command',
+        data: json.encode({
+          'name': 'RefreshAuthor',
+        }),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError('Failed to update library', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to update library', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> triggerRssSync() async {
+    try {
+      await _dio.post(
+        'command',
+        data: json.encode({
+          'name': 'RssSync',
+        }),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError('Failed to trigger RSS sync', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to trigger RSS sync', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> triggerBackup() async {
+    try {
+      await _dio.post(
+        'command',
+        data: json.encode({
+          'name': 'Backup',
+        }),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError('Failed to backup database', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to backup database', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> toggleAuthorMonitored(int authorID, bool status) async {
+    try {
+      Response response = await _dio.get('author/$authorID');
+      Map body = response.data;
+      body['monitored'] = status;
+      response = await _dio.put(
+        'author',
+        data: json.encode(body),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError(
+          'Failed to toggle author monitored status ($authorID)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError(
+          'Failed to toggle author monitored status ($authorID)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> toggleBookMonitored(int bookID, bool status) async {
+    try {
+      Response response = await _dio.get('book/$bookID');
+      Map body = response.data;
+      body['monitored'] = status;
+      response = await _dio.put(
+        'book',
+        data: json.encode(body),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError(
+          'Failed to toggle book monitored status ($bookID)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError(
+          'Failed to toggle book monitored status ($bookID)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<List<ReadarrSearchData>> searchAuthors(String search) async {
+    if (search == '') return [];
+    try {
+      Response response = await _dio.get('author/lookup', queryParameters: {
+        'term': search,
+      });
+      List<ReadarrSearchData> entries = [];
+      for (var entry in response.data) {
+        entries.add(ReadarrSearchData(
+          title: entry['authorName'] ?? 'Unknown Author Name',
+          foreignAuthorId: entry['foreignAuthorId'] ?? '',
+          overview: entry['overview'] == null || entry['overview'] == ''
+              ? 'No Summary Available'
+              : entry['overview'],
+          tadbId: entry['tadbId'] ?? 0,
+          links: entry['links'] ?? [],
+          images: entry['images'] ?? [],
+        ));
+      }
+      return entries;
+    } on DioException catch (error, stack) {
+      logError('Failed to search ($search)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to search ($search)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<int?> addAuthor(
+      ReadarrSearchData entry,
+      ReadarrQualityProfile quality,
+      ReadarrRootFolder rootFolder,
+      ReadarrMetadataProfile metadata,
+      ReadarrMonitorStatus monitorStatus,
+      {bool? search = false}) async {
+    try {
+      Response response = await _dio.post(
+        'author',
+        data: json.encode({
+          'authorName': entry.title,
+          'foreignAuthorId': entry.foreignAuthorId,
+          'qualityProfileId': quality.id,
+          'metadataProfileId': metadata.id,
+          'rootFolderPath': rootFolder.path,
+          'monitored': monitorStatus != ReadarrMonitorStatus.NONE,
+          'addOptions': {
+            'searchForMissingBooks': search,
+            'monitor': monitorStatus.key,
+          },
+        }),
+      );
+      return response.data['id'];
+    } on DioException catch (error, stack) {
+      logError('Failed to add author (${entry.title})', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to add author (${entry.title})', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<List<ReadarrReleaseData>> getReleases(int bookID) async {
+    try {
+      Response response = await _dio.get(
+        'release',
+        queryParameters: {
+          'bookId': bookID,
+        },
+      );
+      List<ReadarrReleaseData> entries = [];
+      for (var entry in response.data) {
+        entries.add(ReadarrReleaseData(
+          title: entry['title'] ?? 'Unknown Title',
+          guid: entry['guid'] ?? '',
+          quality: entry['quality']['quality']['name'] ?? 'Unknown',
+          protocol: entry['protocol'] ?? 'Unknown Protocol',
+          indexer: entry['indexer'] ?? 'Unknown Indexer',
+          infoUrl: entry['infoUrl'] ?? '',
+          approved: entry['approved'] ?? false,
+          releaseWeight: entry['releaseWeight'] ?? 0,
+          size: entry['size'] ?? 0,
+          indexerId: entry['indexerId'] ?? 0,
+          ageHours: entry['ageHours']?.toDouble() ?? 0.0,
+          rejections: entry['rejections'] ?? [],
+          seeders: entry['seeders'] ?? 0,
+          leechers: entry['leechers'] ?? 0,
+        ));
+      }
+      return entries;
+    } on DioException catch (error, stack) {
+      logError('Failed to fetch releases ($bookID)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to fetch releases ($bookID)', error, stack);
+      return Future.error(error);
+    }
+  }
+
+  Future<bool> downloadRelease(String guid, int indexerId) async {
+    try {
+      await _dio.post(
+        'release',
+        data: json.encode({
+          'guid': guid,
+          'indexerId': indexerId,
+        }),
+      );
+      return true;
+    } on DioException catch (error, stack) {
+      logError('Failed to download release ($guid)', error, stack);
+      return Future.error(error);
+    } catch (error, stack) {
+      logError('Failed to download release ($guid)', error, stack);
+      return Future.error(error);
+    }
+  }
 }

--- a/zagreus/lib/modules/readarr/routes/catalogue.dart
+++ b/zagreus/lib/modules/readarr/routes/catalogue.dart
@@ -1,14 +1,195 @@
 import 'package:flutter/material.dart';
+import 'package:zagreus/core.dart';
 import 'package:zagreus/modules/readarr.dart';
 
-class ReadarrCatalogue extends StatelessWidget {
-  const ReadarrCatalogue({Key? key}) : super(key: key);
+class ReadarrCatalogue extends StatefulWidget {
+  static const ROUTE_NAME = '/readarr/catalogue';
+  final GlobalKey<RefreshIndicatorState> refreshIndicatorKey;
+  final Function refreshAllPages;
+
+  const ReadarrCatalogue({
+    Key? key,
+    required this.refreshIndicatorKey,
+    required this.refreshAllPages,
+  }) : super(key: key);
+
+  @override
+  State<ReadarrCatalogue> createState() => _State();
+}
+
+class _State extends State<ReadarrCatalogue>
+    with AutomaticKeepAliveClientMixin, ZagLoadCallbackMixin {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  Future<List<ReadarrCatalogueData>>? _future;
+  List<ReadarrCatalogueData>? _results = [];
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Future<void> loadCallback() async {
+    if (mounted) setState(() => _results = []);
+    final _api = ReadarrAPI.from(ZagProfile.current);
+    if (mounted) {
+      setState(() {
+        _future = _api.getAllAuthors();
+      });
+    }
+  }
+
+  void _refreshState() => setState(() {});
+
+  void _refreshAllPages() => widget.refreshAllPages();
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Authors Catalogue')),
-      body: const Center(child: Text('Authors Catalogue - Coming Soon')),
+    super.build(context);
+    return ZagScaffold(
+      scaffoldKey: _scaffoldKey,
+      body: _body(),
+      appBar: _appBar() as PreferredSizeWidget?,
     );
+  }
+
+  Widget _appBar() {
+    return ZagAppBar.empty(
+      child: ReadarrCatalogueSearchBar(
+        scrollController: ReadarrNavigationBar.scrollControllers[0],
+      ),
+      height: ZagTextInputBar.defaultAppBarHeight,
+    );
+  }
+
+  Widget _body() {
+    return ZagRefreshIndicator(
+      context: context,
+      key: widget.refreshIndicatorKey,
+      onRefresh: loadCallback,
+      child: FutureBuilder(
+        future: _future,
+        builder: (context, AsyncSnapshot<List<ReadarrCatalogueData>> snapshot) {
+          switch (snapshot.connectionState) {
+            case ConnectionState.done:
+              {
+                if (snapshot.hasError || snapshot.data == null) {
+                  return ZagMessage.error(
+                      onTap: () =>
+                          widget.refreshIndicatorKey.currentState?.show);
+                }
+                _results = snapshot.data;
+                return _list();
+              }
+            case ConnectionState.none:
+            case ConnectionState.waiting:
+            case ConnectionState.active:
+            default:
+              return const ZagLoader();
+          }
+        },
+      ),
+    );
+  }
+
+  Widget _list() {
+    if ((_results?.length ?? 0) == 0)
+      return ZagMessage(
+        text: 'No Authors Found',
+        buttonText: 'Refresh',
+        onTap: widget.refreshIndicatorKey.currentState?.show,
+      );
+    return Consumer<ReadarrState>(
+      builder: (context, model, _) {
+        List<ReadarrCatalogueData> _filtered = _filter(_results!, model);
+        _sort(_filtered, model);
+        return Scrollbar(
+          child: ZagListViewBuilder(
+            controller: ReadarrNavigationBar.scrollControllers[0],
+            itemCount: _filtered.length,
+            itemBuilder: (context, index) {
+              return ReadarrCatalogueTile(
+                data: _filtered[index],
+              );
+            },
+            padBottom: true,
+            customHeader: ZagListViewCustomHeaderState<ReadarrCatalogueSorting>(
+              searchFilter: model.searchCatalogueFilter,
+              sortType: model.sortCatalogueType,
+              sortAscending: model.sortCatalogueAscending,
+              onChangedSearchFilter: (value) =>
+                  model.searchCatalogueFilter = value ?? '',
+              hideFilterButton: ReadarrCatalogueHideButton(
+                callback: _refreshState,
+              ),
+              sortButton: ReadarrCatalogueSortingButton(
+                controller: ReadarrNavigationBar.scrollControllers[0],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  List<ReadarrCatalogueData> _filter(
+      List<ReadarrCatalogueData> authors, ReadarrState model) {
+    if (model.searchCatalogueFilter.isEmpty && !model.hideUnmonitoredAuthors)
+      return authors;
+    return authors.where((author) {
+      // Filter by search query
+      if (model.searchCatalogueFilter.isNotEmpty) {
+        String query = model.searchCatalogueFilter.toLowerCase();
+        if (!author.title.toLowerCase().contains(query)) return false;
+      }
+      // Filter by monitored status
+      if (model.hideUnmonitoredAuthors) {
+        if (author.monitored == null || !author.monitored!) return false;
+      }
+      return true;
+    }).toList();
+  }
+
+  void _sort(List<ReadarrCatalogueData> authors, ReadarrState model) {
+    ReadarrCatalogueSorting _sortType = model.sortCatalogueType;
+    bool _ascending = model.sortCatalogueAscending;
+    authors.sort((a, b) {
+      switch (_sortType) {
+        case ReadarrCatalogueSorting.alphabetical:
+          return _ascending
+              ? a.sortTitle.toLowerCase().compareTo(b.sortTitle.toLowerCase())
+              : b.sortTitle.toLowerCase().compareTo(a.sortTitle.toLowerCase());
+        case ReadarrCatalogueSorting.quality:
+          return _ascending
+              ? a.quality.compareTo(b.quality)
+              : b.quality.compareTo(a.quality);
+        case ReadarrCatalogueSorting.metadata:
+          return _ascending
+              ? a.metadata.compareTo(b.metadata)
+              : b.metadata.compareTo(a.metadata);
+        case ReadarrCatalogueSorting.books:
+          {
+            int aBooks = a.statistics['bookCount'] ?? 0;
+            int bBooks = b.statistics['bookCount'] ?? 0;
+            return _ascending ? aBooks.compareTo(bBooks) : bBooks.compareTo(aBooks);
+          }
+        case ReadarrCatalogueSorting.size:
+          return _ascending
+              ? a.sizeOnDisk.compareTo(b.sizeOnDisk)
+              : b.sizeOnDisk.compareTo(a.sizeOnDisk);
+        case ReadarrCatalogueSorting.type:
+          return _ascending
+              ? a.authorType.compareTo(b.authorType)
+              : b.authorType.compareTo(a.authorType);
+        case ReadarrCatalogueSorting.dateAdded:
+          {
+            if (a.dateAddedObject == null && b.dateAddedObject == null)
+              return 0;
+            if (a.dateAddedObject == null) return 1;
+            if (b.dateAddedObject == null) return -1;
+            return _ascending
+                ? a.dateAddedObject!.compareTo(b.dateAddedObject!)
+                : b.dateAddedObject!.compareTo(a.dateAddedObject!);
+          }
+      }
+    });
   }
 }

--- a/zagreus/lib/modules/readarr/routes/readarr.dart
+++ b/zagreus/lib/modules/readarr/routes/readarr.dart
@@ -1,14 +1,203 @@
 import 'package:flutter/material.dart';
+import 'package:zagreus/core.dart';
+import 'package:zagreus/extensions/string/links.dart';
 import 'package:zagreus/modules/readarr.dart';
+import 'package:zagreus/router/routes/readarr.dart';
 
-class ReadarrRoute extends StatelessWidget {
-  const ReadarrRoute({Key? key}) : super(key: key);
+class ReadarrRoute extends StatefulWidget {
+  const ReadarrRoute({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<ReadarrRoute> createState() => _State();
+}
+
+class _State extends State<ReadarrRoute> {
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+  ZagPageController? _pageController;
+  String _profileState = ZagProfile.current.toString();
+  ReadarrAPI _api = ReadarrAPI.from(ZagProfile.current);
+
+  final List _refreshKeys = [
+    GlobalKey<RefreshIndicatorState>(),
+    GlobalKey<RefreshIndicatorState>(),
+    GlobalKey<RefreshIndicatorState>(),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    print('🔍 ReadarrRoute initState() called');
+
+    final initialPage = ReadarrDatabase.NAVIGATION_INDEX.read();
+    print('🔍 Loaded initial index: $initialPage');
+
+    _pageController = ZagPageController(initialPage: initialPage);
+
+    print('🔍 Page controller created with initialPage: $initialPage');
+
+    // Inject global FAB overlay
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ZagGlobalFABManager.instance.injectFAB(context);
+    });
+  }
+
+  @override
+  void deactivate() {
+    print('🔍 ReadarrRoute deactivate() called');
+    super.deactivate();
+  }
+
+  @override
+  void dispose() {
+    _pageController?.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Readarr')),
-      body: const Center(child: Text('Readarr - Coming Soon')),
+    return ZagScaffold(
+      scaffoldKey: _scaffoldKey,
+      module: ZagModule.READARR,
+      body: _body(),
+      drawer: _drawer(),
+      appBar: _appBar() as PreferredSizeWidget?,
+      bottomNavigationBar: _bottomNavigationBar(),
+      onProfileChange: (_) {
+        if (_profileState != ZagProfile.current.toString()) _refreshProfile();
+      },
     );
+  }
+
+  Widget _drawer() => ZagDrawer(page: ZagModule.READARR.key);
+
+  Widget? _bottomNavigationBar() {
+    if (ZagProfile.current.readarrEnabled)
+      return ReadarrNavigationBar(pageController: _pageController);
+    return null;
+  }
+
+  Widget _body() {
+    if (!ZagProfile.current.readarrEnabled)
+      return ZagMessage.moduleNotEnabled(
+        context: context,
+        module: ZagModule.READARR.title,
+      );
+    return ZagPageView(
+      controller: _pageController,
+      children: [
+        ReadarrCatalogue(
+          refreshIndicatorKey: _refreshKeys[0],
+          refreshAllPages: _refreshAllPages,
+        ),
+        ReadarrMissing(
+          refreshIndicatorKey: _refreshKeys[1],
+          refreshAllPages: _refreshAllPages,
+        ),
+        ReadarrHistory(
+          refreshIndicatorKey: _refreshKeys[2],
+          refreshAllPages: _refreshAllPages,
+        ),
+      ],
+    );
+  }
+
+  Widget _appBar() {
+    const db = ZagBox.profiles;
+    final profiles = db.keys.fold<List<String>>([], (arr, key) {
+      if (ZagBox.profiles.read(key)?.readarrEnabled ?? false) arr.add(key);
+      return arr;
+    });
+    List<Widget>? actions;
+    if (ZagProfile.current.readarrEnabled)
+      actions = [
+        ZagIconButton(
+          icon: Icons.add_rounded,
+          onPressed: () async => _enterAddAuthor(),
+        ),
+        ZagIconButton(
+          icon: Icons.more_vert_rounded,
+          onPressed: () async => _handlePopup(),
+        ),
+      ];
+    return ZagAppBar.dropdown(
+      title: ZagModule.READARR.title,
+      useDrawer: true,
+      profiles: profiles,
+      actions: actions,
+      pageController: _pageController,
+      scrollControllers: ReadarrNavigationBar.scrollControllers,
+    );
+  }
+
+  Future<void> _enterAddAuthor() async {
+    final _model = Provider.of<ReadarrState>(context, listen: false);
+    _model.addSearchQuery = '';
+    ReadarrRoutes.ADD_AUTHOR.go();
+  }
+
+  Future<void> _handlePopup() async {
+    List<dynamic> values = await ReadarrDialogs.globalSettings(context);
+    if (values[0])
+      switch (values[1]) {
+        case 'web_gui':
+          ZagProfile profile = ZagProfile.current;
+          await profile.effectiveReadarrHost().openLink();
+          break;
+        case 'update_library':
+          await _api
+              .updateLibrary()
+              .then((_) => showZagSuccessSnackBar(
+                  title: 'Updating Library...',
+                  message: 'Updating your library in the background'))
+              .catchError((error) => showZagErrorSnackBar(
+                  title: 'Failed to Update Library', error: error));
+          break;
+        case 'rss_sync':
+          await _api
+              .triggerRssSync()
+              .then((_) => showZagSuccessSnackBar(
+                  title: 'Running RSS Sync...',
+                  message: 'Running RSS sync in the background'))
+              .catchError((error) => showZagErrorSnackBar(
+                  title: 'Failed to Run RSS Sync', error: error));
+          break;
+        case 'backup':
+          await _api
+              .triggerBackup()
+              .then((_) => showZagSuccessSnackBar(
+                  title: 'Backing Up Database...',
+                  message: 'Backing up database in the background'))
+              .catchError((error) => showZagErrorSnackBar(
+                  title: 'Failed to Backup Database', error: error));
+          break;
+        case 'missing_search':
+          {
+            List<dynamic> values =
+                await ReadarrDialogs.searchAllMissing(context);
+            if (values[0])
+              await _api
+                  .searchAllMissing()
+                  .then((_) => showZagSuccessSnackBar(
+                      title: 'Searching...',
+                      message: 'Search for all missing books'))
+                  .catchError((error) => showZagErrorSnackBar(
+                      title: 'Failed to Search', error: error));
+            break;
+          }
+        default:
+          ZagLogger().warning('Unknown Case: ${values[1]}');
+      }
+  }
+
+  void _refreshProfile() {
+    _api = ReadarrAPI.from(ZagProfile.current);
+    _profileState = ZagProfile.current.toString();
+    _refreshAllPages();
+  }
+
+  void _refreshAllPages() {
+    for (var key in _refreshKeys) key?.currentState?.show();
   }
 }

--- a/zagreus/lib/modules/readarr/widgets/catalogue_tile.dart
+++ b/zagreus/lib/modules/readarr/widgets/catalogue_tile.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:zagreus/core.dart';
 import 'package:zagreus/modules/readarr.dart';
+import 'package:zagreus/router/routes/readarr.dart';
 
 class ReadarrCatalogueTile extends StatelessWidget {
   final ReadarrCatalogueData data;
@@ -11,10 +13,77 @@ class ReadarrCatalogueTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      title: Text(data.title),
-      subtitle: const Text('Author tile placeholder'),
-      leading: const Icon(Icons.person),
+    return ZagCard(
+      child: InkWell(
+        borderRadius: BorderRadius.circular(ZagUI.BORDER_RADIUS),
+        onTap: () => ReadarrRoutes.AUTHOR_DETAILS.go(params: {
+          'author': data.authorID.toString(),
+        }),
+        child: Row(
+          children: [
+            _poster(context),
+            Expanded(child: _details(context)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _poster(BuildContext context) {
+    return ZagNetworkImage(
+      url: data.posterURI(),
+      height: 90.0,
+      width: 60.0,
+      headers: ZagProfile.current.readarrHeaders,
+    );
+  }
+
+  Widget _details(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Author name
+          ZagTitle(text: data.title, maxLines: 1),
+          const SizedBox(height: 4.0),
+          // Subtitle based on sort type
+          Consumer<ReadarrState>(
+            builder: (context, state, _) {
+              String? subtitle = data.subtitle(state.sortCatalogueType);
+              return ZagSubtitle(
+                text: subtitle ?? '',
+                maxLines: 1,
+              );
+            },
+          ),
+          const SizedBox(height: 4.0),
+          // Book statistics
+          Row(
+            children: [
+              Icon(
+                Icons.book,
+                size: 14.0,
+                color: Theme.of(context).textTheme.bodySmall?.color,
+              ),
+              const SizedBox(width: 4.0),
+              Expanded(
+                child: ZagSubtitle(
+                  text: data.bookStats,
+                  maxLines: 1,
+                ),
+              ),
+              // Monitored indicator
+              if (data.monitored == true)
+                Icon(
+                  Icons.visibility,
+                  size: 14.0,
+                  color: ZagColours.currentAccent,
+                ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
This commit wires up the Readarr module with full functionality for browsing and managing authors:

**Backend (ReadarrAPI)**
- Add 20+ missing API methods following Lidarr patterns
- Implement author CRUD operations (get, getAll, add, edit, remove)
- Add book operations (getBooksForAuthor, getBook, toggleMonitored)
- Implement search for adding new authors (searchAuthors)
- Add missing/history retrieval (getMissing, getHistory)
- Implement commands (refresh, updateLibrary, rssSync, backup, searchBooks)
- Add release management (getReleases, downloadRelease)
- Include configuration helpers (getRootFolders, profiles)

**Frontend (UI Components)**
- Implement main ReadarrRoute with 3-tab navigation (Catalogue, Missing, History)
- Wire up ReadarrNavigationBar with proper scroll controllers
- Build ReadarrCatalogue page with full author list display
  - Fetch and display all authors from API
  - Search/filter by author name
  - Filter by monitored status
  - Sort by 7 criteria (alphabetical, quality, metadata, books, size, type, dateAdded)
  - Pull-to-refresh support
  - Loading and error states
- Update ReadarrCatalogueTile to show rich author data
  - Display author poster images
  - Show author name and metadata
  - Display book statistics (downloaded/total)
  - Monitored status indicator
  - Tap to navigate to author details

**Integration**
- Connect app bar with add author and settings menu
- Implement profile switching and refresh
- Add global action handlers (update library, RSS sync, backup, search missing)

The authors catalogue is now fully functional. Users can browse, search, filter, and sort their Readarr library.

Still TODO: Missing page, History page, Author details, Add/Edit flows