### PR TITLE
Fix compilation errors in Readarr module

### DIFF
--- a/zagreus/lib/modules/readarr/routes/add_details.dart
+++ b/zagreus/lib/modules/readarr/routes/add_details.dart
@@ -23,9 +23,9 @@ class _State extends State<AddAuthorDetailsRoute>
     with ZagScrollControllerMixin {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   Future<void>? _future;
-  Map<int, ReadarrRootFolder> _rootFolders = {};
-  Map<int, ReadarrQualityProfile> _qualityProfiles = {};
-  Map<int, ReadarrMetadataProfile> _metadataProfiles = {};
+  List<ReadarrRootFolder> _rootFolders = [];
+  Map<int?, ReadarrQualityProfile> _qualityProfiles = {};
+  Map<int?, ReadarrMetadataProfile> _metadataProfiles = {};
 
   @override
   void initState() {
@@ -53,10 +53,11 @@ class _State extends State<AddAuthorDetailsRoute>
       _rootFolders = values;
       final savedId = ReadarrDatabase.ADD_AUTHOR_DEFAULT_ROOT_FOLDER_ID.read();
       // If saved ID is valid, keep it; otherwise use first folder
-      if (savedId == null || !_rootFolders.containsKey(savedId)) {
+      final hasValidFolder = _rootFolders.any((f) => f.id == savedId);
+      if (savedId == null || !hasValidFolder) {
         if (_rootFolders.isNotEmpty) {
           ReadarrDatabase.ADD_AUTHOR_DEFAULT_ROOT_FOLDER_ID
-              .update(_rootFolders.keys.first);
+              .update(_rootFolders.first.id);
         }
       }
     }).catchError((error) {
@@ -159,7 +160,7 @@ class _State extends State<AddAuthorDetailsRoute>
     return ZagListView(
       controller: scrollController,
       children: <Widget>[
-        ZagDescriptionBlock(
+        ReadarrDescriptionBlock(
           title: widget.data?.title ?? 'zagreus.Unknown'.tr(),
           description: (widget.data?.overview ?? '').isEmpty
               ? 'No Summary Available'
@@ -181,7 +182,10 @@ class _State extends State<AddAuthorDetailsRoute>
           builder: (context, _) {
             final folderId =
                 ReadarrDatabase.ADD_AUTHOR_DEFAULT_ROOT_FOLDER_ID.read();
-            final folder = _rootFolders[folderId];
+            final folder = _rootFolders.cast<ReadarrRootFolder?>().firstWhere(
+              (f) => f?.id == folderId,
+              orElse: () => null,
+            );
             return ZagBlock(
               title: 'Root Folder',
               body: [
@@ -228,7 +232,7 @@ class _State extends State<AddAuthorDetailsRoute>
               trailing: const ZagIconButton.arrow(),
               onTap: () async {
                 List _values = await ReadarrDialogs.editQualityProfile(
-                    context, _qualityProfiles);
+                    context, _qualityProfiles.values.toList());
                 if (_values[0])
                   ReadarrDatabase.ADD_AUTHOR_DEFAULT_QUALITY_PROFILE_ID
                       .update(_values[1].id);
@@ -250,7 +254,7 @@ class _State extends State<AddAuthorDetailsRoute>
               trailing: const ZagIconButton.arrow(),
               onTap: () async {
                 List _values = await ReadarrDialogs.editMetadataProfile(
-                    context, _metadataProfiles);
+                    context, _metadataProfiles.values.toList());
                 if (_values[0])
                   ReadarrDatabase.ADD_AUTHOR_DEFAULT_METADATA_PROFILE_ID
                       .update(_values[1].id);
@@ -274,7 +278,10 @@ class _State extends State<AddAuthorDetailsRoute>
     final metadataProfileId =
         ReadarrDatabase.ADD_AUTHOR_DEFAULT_METADATA_PROFILE_ID.read();
 
-    final rootFolder = _rootFolders[rootFolderId];
+    final rootFolder = _rootFolders.cast<ReadarrRootFolder?>().firstWhere(
+      (f) => f?.id == rootFolderId,
+      orElse: () => null,
+    );
     final qualityProfile = _qualityProfiles[qualityProfileId];
     final metadataProfile = _metadataProfiles[metadataProfileId];
 

--- a/zagreus/lib/modules/readarr/routes/edit_author.dart
+++ b/zagreus/lib/modules/readarr/routes/edit_author.dart
@@ -22,8 +22,8 @@ class _State extends State<AuthorEditRoute> with ZagScrollControllerMixin {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   Future<bool>? _future;
 
-  Map<int, ReadarrQualityProfile> _qualityProfiles = {};
-  Map<int, ReadarrMetadataProfile> _metadataProfiles = {};
+  Map<int?, ReadarrQualityProfile> _qualityProfiles = {};
+  Map<int?, ReadarrMetadataProfile> _metadataProfiles = {};
   ReadarrQualityProfile? _qualityProfile;
   ReadarrMetadataProfile? _metadataProfile;
   String? _path;
@@ -155,13 +155,13 @@ class _State extends State<AuthorEditRoute> with ZagScrollControllerMixin {
 
   Future<void> _changeProfile() async {
     List<dynamic> _values =
-        await ReadarrDialogs.editQualityProfile(context, _qualityProfiles);
+        await ReadarrDialogs.editQualityProfile(context, _qualityProfiles.values.toList());
     if (_values[0] && mounted) setState(() => _qualityProfile = _values[1]);
   }
 
   Future<void> _changeMetadata() async {
     List<dynamic> _values =
-        await ReadarrDialogs.editMetadataProfile(context, _metadataProfiles);
+        await ReadarrDialogs.editMetadataProfile(context, _metadataProfiles.values.toList());
     if (_values[0] && mounted) setState(() => _metadataProfile = _values[1]);
   }
 

--- a/zagreus/lib/modules/readarr/widgets/description_block.dart
+++ b/zagreus/lib/modules/readarr/widgets/description_block.dart
@@ -1,29 +1,51 @@
 import 'package:flutter/material.dart';
-import 'package:zagreus/modules/readarr.dart';
+import 'package:zagreus/core.dart';
 
-class ReadarrDescriptionBlock extends StatelessWidget {
-  final String description;
+class ReadarrDescriptionBlock extends StatefulWidget {
+  final String? description;
+  final String title;
+  final String uri;
+  final bool squareImage;
+  final Map? headers;
+  final Function? onLongPress;
 
   const ReadarrDescriptionBlock({
     Key? key,
     required this.description,
+    required this.title,
+    required this.uri,
+    required this.headers,
+    this.squareImage = false,
+    this.onLongPress,
   }) : super(key: key);
 
   @override
+  State<StatefulWidget> createState() => _State();
+}
+
+class _State extends State<ReadarrDescriptionBlock> {
+  @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Description',
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          const SizedBox(height: 8),
-          Text(description),
-        ],
+    return ZagBlock(
+      title: widget.title,
+      body: [
+        ZagTextSpan.extended(
+          text: widget.description?.isNotEmpty ?? false
+              ? widget.description
+              : 'No Summary Available',
+        ),
+      ],
+      onTap: () async => ZagDialogs().textPreview(
+        context,
+        widget.title,
+        widget.description?.trim() ?? 'No Summary Available',
       ),
+      onLongPress: widget.onLongPress,
+      customBodyMaxLines: 3,
+      posterPlaceholderIcon: ZagIcons.USER,
+      posterHeaders: widget.headers,
+      posterIsSquare: widget.squareImage,
+      posterUrl: widget.uri,
     );
   }
 }

--- a/zagreus/lib/modules/readarr/widgets/details_overview.dart
+++ b/zagreus/lib/modules/readarr/widgets/details_overview.dart
@@ -26,7 +26,7 @@ class _State extends State<ReadarrDetailsOverview>
     return ZagListView(
       controller: ReadarrAuthorNavigationBar.scrollControllers[0],
       children: <Widget>[
-        ZagDescriptionBlock(
+        ReadarrDescriptionBlock(
           title: widget.data.title,
           description: widget.data.overview == ''
               ? 'No Summary Available'


### PR DESCRIPTION
- Fix type mismatches: getRootFolders returns List, getQualityProfiles/getMetadataProfiles return Map<int?, ...>
- Update ReadarrDescriptionBlock to match LidarrDescriptionBlock with all required parameters
- Convert Maps to Lists when passing to dialog methods
- Fix root folder lookup to use firstWhere instead of map indexing