### PR TITLE
Fix naming conflict in ReadarrBookData

### DIFF
--- a/zagreus/lib/modules/readarr/core/api/api.dart
+++ b/zagreus/lib/modules/readarr/core/api/api.dart
@@ -315,7 +315,7 @@ class ReadarrAPI {
         authorName: authorName,
         images: data['images'] as List?,
         links: data['links'] as List?,
-        editions: editions,
+        editionsData: editions,
       );
     } on DioException catch (error, stack) {
       logError('Failed to fetch book ($bookID)', error, stack);

--- a/zagreus/lib/modules/readarr/core/api/data/book.dart
+++ b/zagreus/lib/modules/readarr/core/api/data/book.dart
@@ -16,7 +16,7 @@ class ReadarrBookData {
   String? authorName;
   List<dynamic>? images;
   List<dynamic>? links;
-  List<dynamic>? editions;
+  List<dynamic>? editionsData;
 
   ReadarrBookData({
     required this.bookID,
@@ -32,7 +32,7 @@ class ReadarrBookData {
     this.authorName,
     this.images,
     this.links,
-    this.editions,
+    this.editionsData,
   });
 
   DateTime? get releaseDateObject => DateTime.tryParse(releaseDate)?.toLocal();

--- a/zagreus/lib/modules/readarr/routes/details_book.dart
+++ b/zagreus/lib/modules/readarr/routes/details_book.dart
@@ -126,7 +126,7 @@ class _State extends State<AuthorBookDetailsRoute>
     final headers = ZagProfile.current.readarrHeaders;
 
     // Get first edition data if available
-    final firstEdition = book.editions?.isNotEmpty == true ? book.editions!.first : null;
+    final firstEdition = book.editionsData?.isNotEmpty == true ? book.editionsData!.first : null;
     final pageCount = firstEdition?['pageCount'] as int?;
     final releaseDate = firstEdition?['releaseDate'] as String?;
 


### PR DESCRIPTION
- Renamed 'editions' field to 'editionsData' to avoid conflict with existing getter
- The 'editions' getter returns formatted string like '3 Editions'
- Updated getBook() API method to use editionsData parameter
- Updated Book Details page to use editionsData field