### PR TITLE
Remove app bar from Readarr catalogue page

### DIFF
--- a/zagreus/lib/modules/readarr/routes/catalogue.dart
+++ b/zagreus/lib/modules/readarr/routes/catalogue.dart
@@ -47,13 +47,6 @@ class _State extends State<ReadarrCatalogue>
     return ZagScaffold(
       scaffoldKey: _scaffoldKey,
       body: _body(),
-      appBar: _appBar() as PreferredSizeWidget?,
-    );
-  }
-
-  Widget _appBar() {
-    return ZagAppBar(
-      title: 'Authors (${_results?.length ?? 0})',
     );
   }
 


### PR DESCRIPTION
- Remove ZagAppBar with back button and 'Authors(x)' text
- Clean up unused _appBar() method
- Provides cleaner UI for the catalogue tab