### PR TITLE
Investigate user-reported error with remote connections

### DIFF
--- a/zagreus/lib/modules/lidarr/core/api/api.dart
+++ b/zagreus/lib/modules/lidarr/core/api/api.dart
@@ -6,11 +6,12 @@ class LidarrAPI {
 
   LidarrAPI._internal(this._dio);
   factory LidarrAPI.from(ZagProfile profile) {
+    final effectiveHost = profile.effectiveLidarrHost();
     Dio _client = Dio(
       BaseOptions(
-        baseUrl: profile.lidarrHost.endsWith('/')
-            ? '${profile.lidarrHost}api/v1/'
-            : '${profile.lidarrHost}/api/v1/',
+        baseUrl: effectiveHost.endsWith('/')
+            ? '${effectiveHost}api/v1/'
+            : '${effectiveHost}/api/v1/',
         queryParameters: {
           if (profile.lidarrKey != '') 'apikey': profile.lidarrKey,
         },


### PR DESCRIPTION
LidarrAPI.from() was using profile.lidarrHost directly instead of profile.effectiveLidarrHost(), which bypassed the connection switching logic that routes requests to the local host when connected to trusted SSIDs. This caused Lidarr to always use the primary connection even when the device was on a trusted network with a secondary connection configured.

This fix aligns Lidarr with the pattern used by all other services (Radarr, Sonarr, SABnzbd, NzbGet, Readarr).