### PR TITLE
Make slow server mode extremely slow

### DIFF
--- a/zagreus/lib/api/prowlarr/prowlarr.dart
+++ b/zagreus/lib/api/prowlarr/prowlarr.dart
@@ -56,9 +56,9 @@ class ProwlarrAPI {
         maxRedirects: maxRedirects,
         contentType: Headers.jsonContentType,
         responseType: ResponseType.json,
-        connectTimeout: Duration(seconds: useSlowMode ? 120 : 60),
-        receiveTimeout: Duration(seconds: useSlowMode ? 120 : 60),
-        sendTimeout: Duration(seconds: useSlowMode ? 120 : 60),
+        connectTimeout: Duration(seconds: useSlowMode ? 300 : 60),
+        receiveTimeout: Duration(seconds: useSlowMode ? 300 : 60),
+        sendTimeout: Duration(seconds: useSlowMode ? 300 : 60),
       ),
     );
 

--- a/zagreus/lib/api/radarr/radarr.dart
+++ b/zagreus/lib/api/radarr/radarr.dart
@@ -76,9 +76,9 @@ class RadarrAPI {
         maxRedirects: maxRedirects,
         contentType: Headers.jsonContentType,
         responseType: ResponseType.json,
-        connectTimeout: Duration(seconds: useSlowMode ? 40 : 20),
-        receiveTimeout: Duration(seconds: useSlowMode ? 60 : 30),
-        sendTimeout: Duration(seconds: useSlowMode ? 40 : 20),
+        connectTimeout: Duration(seconds: useSlowMode ? 300 : 20),
+        receiveTimeout: Duration(seconds: useSlowMode ? 300 : 30),
+        sendTimeout: Duration(seconds: useSlowMode ? 300 : 20),
       ),
     );
     return RadarrAPI._internal(

--- a/zagreus/lib/api/readarr/readarr.dart
+++ b/zagreus/lib/api/readarr/readarr.dart
@@ -74,9 +74,9 @@ class ReadarrAPI {
         maxRedirects: maxRedirects,
         contentType: Headers.jsonContentType,
         responseType: ResponseType.json,
-        connectTimeout: Duration(seconds: useSlowMode ? 40 : 20),
-        receiveTimeout: Duration(seconds: useSlowMode ? 60 : 30),
-        sendTimeout: Duration(seconds: useSlowMode ? 40 : 20),
+        connectTimeout: Duration(seconds: useSlowMode ? 300 : 20),
+        receiveTimeout: Duration(seconds: useSlowMode ? 300 : 30),
+        sendTimeout: Duration(seconds: useSlowMode ? 300 : 20),
       ),
     );
     return ReadarrAPI._internal(

--- a/zagreus/lib/api/sonarr/sonarr.dart
+++ b/zagreus/lib/api/sonarr/sonarr.dart
@@ -48,9 +48,9 @@ class SonarrAPI {
         headers: headers,
         followRedirects: followRedirects,
         maxRedirects: maxRedirects,
-        connectTimeout: Duration(seconds: useSlowMode ? 40 : 20),
-        receiveTimeout: Duration(seconds: useSlowMode ? 60 : 30),
-        sendTimeout: Duration(seconds: useSlowMode ? 40 : 20),
+        connectTimeout: Duration(seconds: useSlowMode ? 300 : 20),
+        receiveTimeout: Duration(seconds: useSlowMode ? 300 : 30),
+        sendTimeout: Duration(seconds: useSlowMode ? 300 : 20),
       ),
     );
     return SonarrAPI._internal(


### PR DESCRIPTION
Updated all API clients (Radarr, Sonarr, Prowlarr, Readarr) to use 300-second (5-minute) timeouts when slow server mode is enabled. This provides significantly more patience for slow or overloaded servers.