### PR TITLE
Attempt to fix movie removal menu disappearing on iPad

### DIFF
--- a/zagreus/lib/modules/lidarr/core/dialogs.dart
+++ b/zagreus/lib/modules/lidarr/core/dialogs.dart
@@ -29,6 +29,7 @@ class LidarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _value);
   }
@@ -57,6 +58,7 @@ class LidarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _quality];
   }
@@ -85,6 +87,7 @@ class LidarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _metadata];
   }
@@ -205,6 +208,7 @@ class LidarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _value];
   }
@@ -241,6 +245,7 @@ class LidarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _folder];
   }
@@ -275,6 +280,7 @@ class LidarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _value];
   }
@@ -302,6 +308,7 @@ class LidarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
 
     return [_flag, _index];

--- a/zagreus/lib/modules/radarr/core/dialogs.dart
+++ b/zagreus/lib/modules/radarr/core/dialogs.dart
@@ -29,6 +29,7 @@ class RadarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _value);
   }
@@ -59,6 +60,7 @@ class RadarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _value);
   }

--- a/zagreus/lib/modules/readarr/core/dialogs.dart
+++ b/zagreus/lib/modules/readarr/core/dialogs.dart
@@ -29,6 +29,7 @@ class ReadarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _value);
   }
@@ -57,6 +58,7 @@ class ReadarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _quality];
   }
@@ -85,6 +87,7 @@ class ReadarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _metadata];
   }
@@ -205,6 +208,7 @@ class ReadarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _value];
   }
@@ -241,6 +245,7 @@ class ReadarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _folder];
   }
@@ -275,6 +280,7 @@ class ReadarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return [_flag, _value];
   }
@@ -302,6 +308,7 @@ class ReadarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
 
     return [_flag, _index];

--- a/zagreus/lib/modules/sonarr/core/dialogs.dart
+++ b/zagreus/lib/modules/sonarr/core/dialogs.dart
@@ -30,6 +30,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _value);
   }
@@ -60,6 +61,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _value);
   }
@@ -93,6 +95,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _value);
   }
@@ -125,6 +128,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _value);
   }
@@ -159,6 +163,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _value);
   }
@@ -190,6 +195,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
 
     return [_flag, _index];
@@ -448,6 +454,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, profile);
   }
@@ -476,6 +483,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, profile);
   }
@@ -504,6 +512,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, profile);
   }
@@ -540,6 +549,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _folder);
   }
@@ -568,6 +578,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _type);
   }
@@ -596,6 +607,7 @@ class SonarrDialogs {
         ),
       ),
       contentPadding: ZagDialog.listDialogContentPadding(),
+      barrierDismissible: false,
     );
     return Tuple2(_flag, _type);
   }

--- a/zagreus/lib/widgets/ui/dialog.dart
+++ b/zagreus/lib/widgets/ui/dialog.dart
@@ -269,11 +269,13 @@ abstract class ZagDialog {
     List<Widget>? buttons,
     List<Widget>? content,
     Widget? customContent,
+    bool barrierDismissible = true,
   }) async {
     if (customContent == null)
       assert(content != null, 'customContent and content both cannot be null');
     await showDialog(
       context: context,
+      barrierDismissible: barrierDismissible,
       builder: (context) => AlertDialog(
         actions: <Widget>[
           if (showCancelButton)


### PR DESCRIPTION
Added barrierDismissible: false to all menu-style settings dialogs across Radarr, Sonarr, Lidarr, and Readarr modules to prevent touch event propagation from immediately dismissing the dialog on iPad.

This fixes the issue where tapping the 3-dot menu button causes the menu to appear and immediately close on iPad before the user can select an option.

Changes:
- Added barrierDismissible parameter to ZagDialog.dialog method
- Updated all menu-style dialogs (movieSettings, seriesSettings, episodeSettings, etc.) to use barrierDismissible: false