### PR TITLE
Add speed cube display to Readarr

### DIFF
--- a/zagreus/lib/widgets/ui/global_fab_overlay.dart
+++ b/zagreus/lib/widgets/ui/global_fab_overlay.dart
@@ -113,6 +113,7 @@ class ZagGlobalFABManager {
 
     if (routeLower.contains('sonarr')) return 'sonarr';
     if (routeLower.contains('radarr')) return 'radarr';
+    if (routeLower.contains('readarr')) return 'readarr';
     if (routeLower.contains('lidarr')) return 'lidarr';
     if (routeLower.contains('tautulli')) return 'tautulli';
     if (routeLower.contains('sabnzbd')) return 'sabnzbd';


### PR DESCRIPTION
- Add 'readarr' route detection in ZagGlobalFABManager._extractModuleFromRoute()
- Ensures speed cube properly identifies when user is in Readarr module
- Allows speed cube to display correctly in Readarr views
- Completes Readarr integration with the speed cube system