### PR TITLE
Ensure Overseerr Pro restriction is consistent across settings

### DIFF
--- a/zagreus/lib/modules/settings/routes/configuration/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration/route.dart
@@ -132,7 +132,9 @@ class _State extends State<ConfigurationRoute> with ZagScrollControllerMixin {
     if (!isPro) {
       modules.removeWhere(
         (module) =>
-            module == ZagModule.DISCOVER || module == ZagModule.OVERSEERR,
+            module == ZagModule.DISCOVER ||
+            module == ZagModule.OVERSEERR ||
+            module == ZagModule.UNRAID,
       );
     } else {
       // Move DISCOVER to right after DASHBOARD if user has Pro


### PR DESCRIPTION
Fixed inconsistency in settings configuration where Overseerr and Unraid
were not filtered from the module list for non-Pro users. This brings the
settings configuration in line with other parts of the app that already
properly restrict these Pro-only modules.

Changes:
- Added ZagModule.UNRAID to Pro-locked modules filter in configuration route
- Ensures consistent behavior with drawer and module dashboard restrictions