### PR TITLE
Show Agent/Search on Modules tab for premium users, add download icon…

### DIFF
--- a/zagreus/lib/modules.dart
+++ b/zagreus/lib/modules.dart
@@ -185,7 +185,7 @@ extension ZagModuleMetadataExtension on ZagModule {
   String get title {
     switch (this) {
       case ZagModule.DASHBOARD:
-        return 'Home';
+        return 'zagreus.Dashboard'.tr();
       case ZagModule.LIDARR:
         return 'Lidarr';
       case ZagModule.NZBGET:

--- a/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
@@ -102,7 +102,7 @@ class _State extends State<DashboardRoute> {
             if (controller == null) return const SizedBox();
             final currentPage = controller.hasClients ? controller.page?.round() ?? 0 : 0;
             if (currentPage == 0) {
-              // Only show search and agent buttons for premium users
+              // Show search and agent buttons for premium users, download icon for free users
               final isPremium = ZagreusMega.isEnabled || ZagreusUltra.isEnabled;
               if (isPremium) {
                 return Row(
@@ -119,8 +119,14 @@ class _State extends State<DashboardRoute> {
                     ),
                   ],
                 );
+              } else {
+                // Free users: show download icon
+                return IconButton(
+                  icon: const Icon(Icons.download_rounded),
+                  tooltip: 'Downloads',
+                  onPressed: () => _scaffoldKey.currentState?.openEndDrawer(),
+                );
               }
-              return const SizedBox();
             }
             return SwitchViewAction(pageController: _pageController);
           },

--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -1448,10 +1448,12 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   List<Widget>? _buildAppBarActions() {
     final enableLegacyModules = _showLegacyModules;
     final showAgentTab = _showAgentTab;
+    final modulesTabIndex = 0;
     final moviesTabIndex = enableLegacyModules ? 1 : 0;
     final showsTabIndex = enableLegacyModules ? 2 : 1;
     final calendarIndex = enableLegacyModules ? 3 : 2;
     final serverIndex = enableLegacyModules ? 4 : 3;
+    final isPremium = ZagreusMega.isEnabled || ZagreusUltra.isEnabled;
 
     if (_isSearchActive) {
       return [
@@ -1499,9 +1501,42 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     }
 
     final actions = <Widget>[];
-    if (_currentPageIndex == moviesTabIndex ||
+
+    // Show Agent and Search icons on Modules, Movies, Shows, and Server tabs for premium users
+    // Show download icon for free users on Modules tab
+    if (enableLegacyModules && _currentPageIndex == modulesTabIndex) {
+      // Modules tab
+      if (isPremium) {
+        if (showAgentTab) {
+          actions.add(
+            IconButton(
+              icon: const Icon(Icons.smart_toy),
+              tooltip: 'Z Agent',
+              onPressed: _openAgentOverlay,
+            ),
+          );
+        }
+        actions.add(
+          IconButton(
+            icon: const Icon(Icons.search_rounded),
+            tooltip: 'Search',
+            onPressed: _openSearchOverlay,
+          ),
+        );
+      } else {
+        // Free users: show download icon
+        actions.add(
+          IconButton(
+            icon: const Icon(Icons.download_rounded),
+            tooltip: 'Downloads',
+            onPressed: () => _scaffoldKey.currentState?.openEndDrawer(),
+          ),
+        );
+      }
+    } else if (_currentPageIndex == moviesTabIndex ||
         _currentPageIndex == showsTabIndex ||
         _currentPageIndex == serverIndex) {
+      // Movies, Shows, and Server tabs
       if (showAgentTab) {
         actions.add(
           IconButton(


### PR DESCRIPTION
… for free users

Changes to icon visibility in Dashboard modules:
1. Premium users (Mega/Ultra) now see Agent and Search icons on the Modules tab
2. Free users see a download icon on Modules tab to access the downloads drawer
3. Both DASHBOARD and DISCOVER modules now display as "Dashboard" with consistent home icon and accent color theme for seamless experience

This ensures:
- Premium users have consistent access to Agent and Search across all tabs
- Free users have easy access to downloads drawer without the hamburger icon issue
- Unified branding between free and premium Dashboard experiences

Files changed:
- modules/discover/routes/discover/route.dart: Updated _buildAppBarActions() to show Agent/Search on Modules tab for premium, download icon for free users
- modules/dashboard/routes/dashboard/route.dart: Added download icon for free users
- modules.dart: Changed DASHBOARD title from "Home" to "Dashboard" for consistency