### PR TITLE
Hide Dashboard module from modules list for premium users

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/pages/modules.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/pages/modules.dart
@@ -60,7 +60,12 @@ class _State extends State<ModulesPage> with AutomaticKeepAliveClientMixin {
         if (_requiresPro(module) && !ZagreusPro.isEnabled) {
           return;
         }
-        
+
+        // Skip Dashboard module for premium users (redundant)
+        if (module == ZagModule.DASHBOARD && ZagreusPro.isEnabled) {
+          return;
+        }
+
         if (module.isEnabled) {
           if (module == ZagModule.WAKE_ON_LAN) {
             modules.add(_buildWakeOnLAN(context, index));
@@ -82,7 +87,12 @@ class _State extends State<ModulesPage> with AutomaticKeepAliveClientMixin {
       if (_requiresPro(module) && !ZagreusPro.isEnabled) {
         return;
       }
-      
+
+      // Skip Dashboard module for premium users (redundant)
+      if (module == ZagModule.DASHBOARD && ZagreusPro.isEnabled) {
+        return;
+      }
+
       if (module.isEnabled) {
         if (module == ZagModule.WAKE_ON_LAN) {
           modules.add(_buildWakeOnLAN(context, index));


### PR DESCRIPTION
Added logic to skip displaying the Dashboard module on the modules page for premium users (Pro/Mega/Ultra) to avoid redundancy, since the modules page is already inside Dashboard.

Free users don't see this issue as they don't have access to the premium Dashboard module (DISCOVER), so their Home module (DASHBOARD) is already contextually different.

Changes:
- Skip Dashboard module in alphabetical list for premium users
- Skip Dashboard module in manually ordered list for premium users