### PR TITLE
Fix: Hide Discover module (not Dashboard) from modules list

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/pages/modules.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/pages/modules.dart
@@ -61,8 +61,8 @@ class _State extends State<ModulesPage> with AutomaticKeepAliveClientMixin {
           return;
         }
 
-        // Skip Dashboard module for premium users (redundant)
-        if (module == ZagModule.DASHBOARD && ZagreusPro.isEnabled) {
+        // Skip Discover module for premium users (redundant - they're already in it)
+        if (module == ZagModule.DISCOVER && ZagreusPro.isEnabled) {
           return;
         }
 
@@ -88,8 +88,8 @@ class _State extends State<ModulesPage> with AutomaticKeepAliveClientMixin {
         return;
       }
 
-      // Skip Dashboard module for premium users (redundant)
-      if (module == ZagModule.DASHBOARD && ZagreusPro.isEnabled) {
+      // Skip Discover module for premium users (redundant - they're already in it)
+      if (module == ZagModule.DISCOVER && ZagreusPro.isEnabled) {
         return;
       }
 


### PR DESCRIPTION
Corrected the logic to hide the DISCOVER module (premium Dashboard) from the modules list, not the DASHBOARD module (free Home).

Premium users view the Modules tab from inside the DISCOVER module, so seeing "Dashboard" listed there would be redundant and clicking it would do nothing since they're already in it.

Changes:
- Changed from hiding ZagModule.DASHBOARD to hiding ZagModule.DISCOVER
- Updated comments to clarify this is the Discover module being hidden