### PR TITLE
Add clarifying comment for Calendar tab view switcher

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
@@ -102,8 +102,9 @@ class _State extends State<DashboardRoute> {
             final controller = _pageController;
             if (controller == null) return const SizedBox();
             final currentPage = controller.hasClients ? controller.page?.round() ?? 0 : 0;
+
             if (currentPage == 0) {
-              // Show search and agent buttons based on tier
+              // Modules tab - show tier-based icons
               final isMegaOrUltra = ZagreusMega.isEnabled || ZagreusUltra.isEnabled;
               final isPro = ZagreusPro.isEnabled;
 
@@ -139,6 +140,8 @@ class _State extends State<DashboardRoute> {
                 );
               }
             }
+
+            // Calendar tab (page 1) - show view switcher for all users
             return SwitchViewAction(pageController: _pageController);
           },
         ),


### PR DESCRIPTION
Added comment to clarify that the view switcher icon (SwitchViewAction) is shown on the Calendar tab for all users - free, Pro, Mega, and Ultra.

This ensures free users can switch between daily and schedule views just like premium users can.

Changes:
- Added comment clarifying Calendar tab shows view switcher for all users
- Improved code formatting for better readability