### PR TITLE
Fix: Calendar tab now shows view switcher for free users

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
@@ -40,6 +40,11 @@ class _State extends State<DashboardRoute> {
     int page = DashboardDatabase.NAVIGATION_INDEX.read();
     _pageController = ZagPageController(initialPage: page);
 
+    // Add listener to rebuild app bar when page changes
+    _pageController?.addListener(() {
+      if (mounted) setState(() {});
+    });
+
     // Inject global FAB overlay
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ZagGlobalFABManager.instance.injectFAB(context);
@@ -54,6 +59,12 @@ class _State extends State<DashboardRoute> {
         _updateWidget();
       });
     }
+  }
+
+  @override
+  void dispose() {
+    _pageController?.dispose();
+    super.dispose();
   }
 
   Future<void> _updateWidget() async {


### PR DESCRIPTION
Added page controller listener to Dashboard route so the app bar rebuilds when swiping between tabs. Previously, free users saw the download icon on the Calendar tab instead of the view switcher because the Builder in the app bar actions wasn't rebuilding when the page changed.

Now when users swipe from Modules tab (page 0) to Calendar tab (page 1), setState is called, the app bar rebuilds, and the correct icon is shown:
- Modules tab (page 0): Tier-based icons (download for free, search for Pro, etc.)
- Calendar tab (page 1): View switcher for ALL users

Changes:
- Added page controller listener in initState to call setState on page change
- Added dispose method to properly clean up page controller