### PR TITLE
Investigate deep cuts generation for premium users

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -206,6 +206,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
 
   // Deep Cuts future (cached to avoid refetching on rebuild)
   Future<DeepCutsResult>? _deepCutsFuture;
+  bool _deepCutsSyncInitialized = false;
 
   @override
   void initState() {
@@ -228,6 +229,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     // Don't load popular movies or people here - will do it in didChangeDependencies
     _loadMockTrendingData();
     _startAutoScroll();
+    _syncDeepCutsIfNeeded();
   }
 
   void _refreshQuickSetupModal() {
@@ -245,20 +247,27 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     _loadMostAnticipatedMovies();
     _loadPopularPeople();
     _loadSonarrAiringNext();
-    _syncDeepCutsIfNeeded();
   }
 
   Future<void> _syncDeepCutsIfNeeded() async {
-    if (!ZagreusMega.isEnabled) return;
+    // Guard to ensure this only runs once
+    if (_deepCutsSyncInitialized || !ZagreusMega.isEnabled) return;
+    _deepCutsSyncInitialized = true;
 
     try {
       final deepCutsService = DeepCutsService();
-      final needsRegen = await deepCutsService.needsRegeneration();
+      // Fetch current state once
+      final fetchResult = await deepCutsService.fetchRecommendations();
+
+      // Check if regeneration is needed based on fetched data
+      final needsRegen = deepCutsService.needsRegeneration(
+        existingResult: fetchResult,
+      );
 
       if (needsRegen) {
         ZagLogger().debug('Deep Cuts need regeneration - triggering...');
         // Fire and forget - don't await
-        deepCutsService.syncIfNeeded();
+        deepCutsService.generateRecommendations();
       }
     } catch (e, stack) {
       ZagLogger().error('Deep Cuts sync check failed', e, stack);
@@ -5757,11 +5766,14 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     return FutureBuilder<DeepCutsResult>(
       future: _deepCutsFuture,
       builder: (context, futureSnapshot) {
-        // Check if refresh is available (nextGenerationAt has passed)
+        // Only show refresh button if:
+        // 1. We have no data yet (empty state) OR
+        // 2. We have data but it's time for regeneration (nextGenerationAt has passed)
+        // Do NOT show if we have a successful list that's still fresh
         final canRefresh = !futureSnapshot.hasData ||
             !futureSnapshot.data!.success ||
-            futureSnapshot.data!.nextGenerationAt == null ||
-            DateTime.now().isAfter(futureSnapshot.data!.nextGenerationAt!);
+            (futureSnapshot.data!.nextGenerationAt != null &&
+                DateTime.now().isAfter(futureSnapshot.data!.nextGenerationAt!));
 
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/zagreus/lib/services/deep_cuts_service.dart
+++ b/zagreus/lib/services/deep_cuts_service.dart
@@ -105,21 +105,17 @@ class DeepCutsService {
   }
 
   /// Check if recommendations need regeneration (> 7 days old or never generated)
-  Future<bool> needsRegeneration() async {
+  /// Pass existing result to avoid redundant API calls
+  bool needsRegeneration({DeepCutsResult? existingResult}) {
     if (!ZagreusMega.isEnabled) return false;
 
-    try {
-      final result = await fetchRecommendations();
-      if (!result.success || result.nextGenerationAt == null) {
-        return true; // No data or error, should try to generate
-      }
-
-      // Check if it's time for next generation
-      return DateTime.now().isAfter(result.nextGenerationAt!);
-    } catch (e, stack) {
-      ZagLogger().error('Error checking regeneration status', e, stack);
-      return false;
+    if (existingResult == null) return true;
+    if (!existingResult.success || existingResult.nextGenerationAt == null) {
+      return true; // No data or error, should try to generate
     }
+
+    // Check if it's time for next generation
+    return DateTime.now().isAfter(existingResult.nextGenerationAt!);
   }
 
   /// Fetch cached Deep Cuts recommendations from backend
@@ -297,14 +293,14 @@ class DeepCutsService {
 
   /// Convenience method to fetch or generate as needed
   Future<DeepCutsResult> syncIfNeeded() async {
-    // First try to fetch existing
+    // First try to fetch existing - do this ONCE
     final fetchResult = await fetchRecommendations();
 
     if (fetchResult.success && fetchResult.recommendations!.isNotEmpty) {
-      // Check if regeneration is needed
-      final needsRegen = await needsRegeneration();
+      // Check if regeneration is needed based on the result we just fetched
+      final needsRegen = needsRegeneration(existingResult: fetchResult);
       if (!needsRegen) {
-        return fetchResult; // All good
+        return fetchResult; // All good, return what we already have
       }
     }
 


### PR DESCRIPTION
This commit fixes multiple issues causing deep cuts generation to be slow, redundant, and triggered multiple times on startup:

**Service Layer (deep_cuts_service.dart):**
- Refactored needsRegeneration() to accept optional existing result, eliminating redundant API calls (was fetching 3-4 times per check)
- Simplified syncIfNeeded() to fetch once and reuse the result for regeneration check instead of fetching twice
- Changed needsRegeneration() from async to sync since it no longer needs to fetch data

**UI Layer (discover/route.dart):**
- Moved _syncDeepCutsIfNeeded() from didChangeDependencies() to initState() to prevent multiple triggers during widget lifecycle
- Added _deepCutsSyncInitialized guard flag to ensure sync only runs once
- Updated _syncDeepCutsIfNeeded() to fetch once and pass result to needsRegeneration() check
- Fixed refresh button visibility logic to only show when:
  - No data exists yet (empty state), OR
  - Time has passed for regeneration (nextGenerationAt expired)
  - Previously showed refresh button even with fresh successful lists

These changes eliminate redundant API calls, prevent multiple startup syncs, and improve the user experience by not showing unnecessary refresh prompts.