### PR TITLE
Update ZagProfile to use Unraid module

### DIFF
--- a/zagreus/lib/database/models/profile.dart
+++ b/zagreus/lib/database/models/profile.dart
@@ -200,27 +200,27 @@ class ZagProfile extends HiveObject {
 
   @JsonKey()
   @HiveField(44, defaultValue: false)
-  bool serverEnabled;
+  bool unraidEnabled;
 
   @JsonKey()
   @HiveField(45, defaultValue: '')
-  String serverHost;
+  String unraidHost;
 
   @JsonKey()
   @HiveField(46, defaultValue: '')
-  String serverKey;
+  String unraidKey;
 
   @JsonKey()
   @HiveField(47, defaultValue: <String, String>{})
-  Map<String, String> serverHeaders;
+  Map<String, String> unraidHeaders;
 
   @JsonKey()
   @HiveField(60, defaultValue: '')
-  String serverLocalHost;
+  String unraidLocalHost;
 
   @JsonKey()
   @HiveField(61, defaultValue: '')
-  String serverLocalSsids;
+  String unraidLocalSsids;
 
   @JsonKey()
   @HiveField(62, defaultValue: false)
@@ -299,13 +299,13 @@ class ZagProfile extends HiveObject {
     required this.overseerrHost,
     required this.overseerrKey,
     required this.overseerrHeaders,
-    //Server
-    required this.serverEnabled,
-    required this.serverHost,
-    required this.serverKey,
-    required this.serverHeaders,
-    required this.serverLocalHost,
-    required this.serverLocalSsids,
+    //Unraid
+    required this.unraidEnabled,
+    required this.unraidHost,
+    required this.unraidKey,
+    required this.unraidHeaders,
+    required this.unraidLocalHost,
+    required this.unraidLocalSsids,
     //Readarr
     required this.readarrEnabled,
     required this.readarrHost,
@@ -368,13 +368,13 @@ class ZagProfile extends HiveObject {
     String? overseerrHost,
     String? overseerrKey,
     Map<String, String>? overseerrHeaders,
-    //Server
-    bool? serverEnabled,
-    String? serverHost,
-    String? serverKey,
-    Map<String, String>? serverHeaders,
-    String? serverLocalHost,
-    String? serverLocalSsids,
+    //Unraid
+    bool? unraidEnabled,
+    String? unraidHost,
+    String? unraidKey,
+    Map<String, String>? unraidHeaders,
+    String? unraidLocalHost,
+    String? unraidLocalSsids,
     //Readarr
     bool? readarrEnabled,
     String? readarrHost,
@@ -436,13 +436,13 @@ class ZagProfile extends HiveObject {
       overseerrHost: overseerrHost ?? '',
       overseerrKey: overseerrKey ?? '',
       overseerrHeaders: overseerrHeaders ?? {},
-      // Server
-      serverEnabled: serverEnabled ?? false,
-      serverHost: serverHost ?? '',
-      serverKey: serverKey ?? '',
-      serverHeaders: serverHeaders ?? {},
-      serverLocalHost: serverLocalHost ?? '',
-      serverLocalSsids: serverLocalSsids ?? '',
+      // Unraid
+      unraidEnabled: unraidEnabled ?? false,
+      unraidHost: unraidHost ?? '',
+      unraidKey: unraidKey ?? '',
+      unraidHeaders: unraidHeaders ?? {},
+      unraidLocalHost: unraidLocalHost ?? '',
+      unraidLocalSsids: unraidLocalSsids ?? '',
       // Readarr
       readarrEnabled: readarrEnabled ?? false,
       readarrHost: readarrHost ?? '',
@@ -517,10 +517,10 @@ class ZagProfile extends HiveObject {
         ssidList: tautulliLocalSsids,
       );
 
-  String effectiveServerHost() => ZagLocalConnectionService().resolveHost(
-        remoteHost: serverHost,
-        localHost: serverLocalHost,
-        ssidList: serverLocalSsids,
+  String effectiveUnraidHost() => ZagLocalConnectionService().resolveHost(
+        remoteHost: unraidHost,
+        localHost: unraidLocalHost,
+        ssidList: unraidLocalSsids,
       );
 
   String effectiveReadarrHost() => ZagLocalConnectionService().resolveHost(

--- a/zagreus/lib/modules.dart
+++ b/zagreus/lib/modules.dart
@@ -172,7 +172,7 @@ extension ZagModuleEnablementExtension on ZagModule {
       case ZagModule.DISCOVER:
         return true;
       case ZagModule.UNRAID:
-        return ZagProfile.current.serverEnabled;
+        return ZagProfile.current.unraidEnabled;
       case ZagModule.PROWLARR:
         return !ZagBox.indexers.isEmpty;
       case ZagModule.READARR:

--- a/zagreus/lib/modules/settings/core/pages/headers.dart
+++ b/zagreus/lib/modules/settings/core/pages/headers.dart
@@ -122,7 +122,7 @@ class _State extends State<SettingsHeaderRoute> with ZagScrollControllerMixin {
       case ZagModule.TAUTULLI:
         return ZagProfile.current.tautulliHeaders;
       case ZagModule.UNRAID:
-        return ZagProfile.current.serverHeaders;
+        return ZagProfile.current.unraidHeaders;
       case ZagModule.DISCOVER:
         throw Exception('Discover does not have a headers page');
       case ZagModule.PROWLARR:

--- a/zagreus/lib/modules/settings/routes/configuration_unraid/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_unraid/pages/connection_details.dart
@@ -91,7 +91,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
       ];
 
   Widget _remoteHost() {
-    String host = ZagProfile.current.serverHost;
+    String host = ZagProfile.current.unraidHost;
     return ZagBlock(
       title: 'settings.Host'.tr(),
       body: [TextSpan(text: host.isEmpty ? 'zagreus.NotSet'.tr() : host)],
@@ -102,7 +102,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
           prefill: host,
         );
         if (_values.item1) {
-          ZagProfile.current.serverHost = _values.item2;
+          ZagProfile.current.unraidHost = _values.item2;
           ZagProfile.current.save();
           context.read<UnraidState>().reset();
         }
@@ -112,7 +112,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
 
   Widget _localHost() {
     final profile = ZagProfile.current;
-    final host = profile.serverLocalHost;
+    final host = profile.unraidLocalHost;
     return ZagBlock(
       title: 'settings.LocalHost'.tr(),
       body: [TextSpan(text: host.isEmpty ? 'zagreus.NotSet'.tr() : host)],
@@ -123,7 +123,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
           prefill: host,
         );
         if (result.item1) {
-          profile.serverLocalHost = result.item2;
+          profile.unraidLocalHost = result.item2;
           profile.save();
           await ZagLocalConnectionService().refreshSsid();
           context.read<UnraidState>().reset();
@@ -134,7 +134,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
 
   Widget _localSsids() {
     final profile = ZagProfile.current;
-    final ssids = profile.serverLocalSsids;
+    final ssids = profile.unraidLocalSsids;
     return ZagBlock(
       title: 'settings.TrustedSsids'.tr(),
       body: [
@@ -151,7 +151,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
           extraText: [TextSpan(text: 'settings.TrustedSsidsHint'.tr())],
         );
         if (result.item1) {
-          profile.serverLocalSsids = result.item2;
+          profile.unraidLocalSsids = result.item2;
           profile.save();
           await ZagLocalConnectionService().refreshSsid();
           context.read<UnraidState>().reset();
@@ -169,8 +169,8 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
         final profile = ZagProfile.current;
         final advancedEnabled =
             ZagreusDatabase.NETWORKING_LOCAL_SWITCHING_ENABLED.read();
-        final hasLocalHost = profile.serverLocalHost.isNotEmpty;
-        final hasSsids = profile.serverLocalSsids.trim().isNotEmpty;
+        final hasLocalHost = profile.unraidLocalHost.isNotEmpty;
+        final hasSsids = profile.unraidLocalSsids.trim().isNotEmpty;
         final localConfigured = advancedEnabled && hasLocalHost && hasSsids;
 
         final title = 'settings.ConnectionStatus'.tr();
@@ -187,9 +187,9 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
           );
         }
 
-        final effectiveHost = profile.effectiveServerHost();
+        final effectiveHost = profile.effectiveUnraidHost();
         final networkLabel = ssid ?? 'network.UnknownSsid'.tr();
-        final usingLocal = effectiveHost == profile.serverLocalHost;
+        final usingLocal = effectiveHost == profile.unraidLocalHost;
 
         final statusText = usingLocal
             ? 'settings.ConnectionStatusLocal'.tr(args: [networkLabel])
@@ -209,7 +209,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
   }
 
   Widget _apiKey() {
-    String apiKey = ZagProfile.current.serverKey;
+    String apiKey = ZagProfile.current.unraidKey;
     return ZagBlock(
       title: 'settings.ApiKey'.tr(),
       body: [
@@ -227,7 +227,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
           prefill: apiKey,
         );
         if (_values.item1) {
-          ZagProfile.current.serverKey = _values.item2;
+          ZagProfile.current.unraidKey = _values.item2;
           ZagProfile.current.save();
           context.read<UnraidState>().reset();
         }
@@ -250,7 +250,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
       icon: ZagIcons.CONNECTION_TEST,
       onTap: () async {
         ZagProfile _profile = ZagProfile.current;
-        final effectiveHost = _profile.effectiveServerHost();
+        final effectiveHost = _profile.effectiveUnraidHost();
         if (effectiveHost.isEmpty) {
           showZagErrorSnackBar(
             title: 'settings.HostRequired'.tr(),
@@ -259,7 +259,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
           );
           return;
         }
-        if (_profile.serverKey.isEmpty) {
+        if (_profile.unraidKey.isEmpty) {
           showZagErrorSnackBar(
             title: 'settings.ApiKeyRequired'.tr(),
             message: 'settings.ApiKeyRequiredMessage'
@@ -269,8 +269,8 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
         }
         UnraidAPI(
           host: effectiveHost,
-          apiKey: _profile.serverKey,
-          headers: Map<String, dynamic>.from(_profile.serverHeaders),
+          apiKey: _profile.unraidKey,
+          headers: Map<String, dynamic>.from(_profile.unraidHeaders),
         ).getSystemInfo().then(
           (info) {
             showZagSuccessSnackBar(

--- a/zagreus/lib/modules/settings/routes/configuration_unraid/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_unraid/route.dart
@@ -48,9 +48,9 @@ class _State extends State<ConfigurationUnraidRoute>
       builder: (context, _) => ZagBlock(
         title: 'settings.EnableModule'.tr(args: [ZagModule.UNRAID.title]),
         trailing: ZagSwitch(
-          value: ZagProfile.current.serverEnabled,
+          value: ZagProfile.current.unraidEnabled,
           onChanged: (value) {
-            ZagProfile.current.serverEnabled = value;
+            ZagProfile.current.unraidEnabled = value;
             ZagProfile.current.save();
             context.read<UnraidState>().reset();
           },

--- a/zagreus/lib/modules/settings/routes/system/route.dart
+++ b/zagreus/lib/modules/settings/routes/system/route.dart
@@ -246,13 +246,13 @@ class _State extends State<SystemRoute> with ZagScrollControllerMixin {
       overseerrHost: demoConfig['overseerr_host'] ?? '',
       overseerrKey: demoConfig['overseerr_key'] ?? '',
       overseerrHeaders: {},
-      // Server
-      serverEnabled: demoConfig['server_enabled'] ?? true,
-      serverHost:
-          demoConfig['server_host'] ?? 'https://tower.zagreus.app/',
-      serverKey: demoConfig['server_key'] ??
+      // Unraid
+      unraidEnabled: demoConfig['unraid_enabled'] ?? true,
+      unraidHost:
+          demoConfig['unraid_host'] ?? 'https://tower.zagreus.app/',
+      unraidKey: demoConfig['unraid_key'] ??
           '4f881bebb9da6a41431cfa5b194b36fa12094a87b5164886542ddfa2e235066c',
-      serverHeaders: const <String, String>{},
+      unraidHeaders: const <String, String>{},
     );
 
     // Save the profile

--- a/zagreus/lib/modules/unraid/core/state.dart
+++ b/zagreus/lib/modules/unraid/core/state.dart
@@ -41,9 +41,9 @@ class UnraidState extends ZagModuleState {
     ZagLogger().debug('UnraidState.resetProfile called');
     ZagProfile profile = ZagProfile.current;
     // Copy profile into state
-    _enabled = profile.serverEnabled;
-    _host = profile.effectiveServerHost();
-    _apiKey = profile.serverKey;
-    _headers = Map.unmodifiable(profile.serverHeaders);
+    _enabled = profile.unraidEnabled;
+    _host = profile.effectiveUnraidHost();
+    _apiKey = profile.unraidKey;
+    _headers = Map.unmodifiable(profile.unraidHeaders);
   }
 }

--- a/zagreus/lib/system/network/local_switching_service.dart
+++ b/zagreus/lib/system/network/local_switching_service.dart
@@ -246,9 +246,9 @@ class ZagLocalConnectionService {
       ),
       _LocalSwitchConfig(
         module: ZagModule.UNRAID,
-        enabled: profile.serverEnabled,
-        localHost: profile.serverLocalHost,
-        ssids: profile.serverLocalSsids,
+        enabled: profile.unraidEnabled,
+        localHost: profile.unraidLocalHost,
+        ssids: profile.unraidLocalSsids,
       ),
     ];
   }


### PR DESCRIPTION
Updated all ZagProfile parameters to use the "unraid" naming convention instead of "server" to better reflect the module name. This includes:

- Field names: serverEnabled → unraidEnabled, serverHost → unraidHost, etc.
- Method names: effectiveServerHost() → effectiveUnraidHost()
- All references across the codebase updated accordingly

This change maintains backward compatibility with the Hive database schema (field IDs remain unchanged).