### PR TITLE
Reduce excessive logging output

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -982,22 +982,18 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   }
 
   Future<void> _loadPopularTVShows() async {
-    print('📺 Loading popular TV shows...');
     try {
       // Get user's region from locale
       final locale = Localizations.localeOf(context);
       final region = locale.countryCode ?? 'US';
-      print('📺 Using region: $region');
 
       final shows = await TMDBApi.getPopularTVShows(region: region);
-      print('📺 Got ${shows.length} popular TV shows from TMDB');
 
       // Check against Sonarr library if available
       final sonarrState = context.read<SonarrState>();
       if (sonarrState.enabled && sonarrState.api != null) {
         try {
           final sonarrSeries = await sonarrState.api!.series.getAll();
-          print('📺 Checking against ${sonarrSeries.length} Sonarr series');
 
           for (final show in shows) {
             final tmdbId = show['tmdbId'] as int;
@@ -1030,30 +1026,25 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
           _popularTVShows =
               shows.take(10).toList(); // Limit to 10 for the section
         });
-        print('📺 Set ${_popularTVShows.length} popular TV shows in state');
       }
     } catch (e) {
-      print('❌ Error loading popular TV shows: $e');
+      ZagLogger().error('Error loading popular TV shows', e, StackTrace.current);
     }
   }
 
   Future<void> _loadTrendingNewTVShows() async {
-    print('🆕 Loading trending new TV shows...');
     try {
       // Get user's region from locale
       final locale = Localizations.localeOf(context);
       final region = locale.countryCode ?? 'US';
-      print('🆕 Using region: $region');
 
       final shows = await TMDBApi.getTrendingNewTVShows(region: region);
-      print('🆕 Got ${shows.length} trending new TV shows from TMDB');
 
       // Check against Sonarr library if available
       final sonarrState = context.read<SonarrState>();
       if (sonarrState.enabled && sonarrState.api != null) {
         try {
           final sonarrSeries = await sonarrState.api!.series.getAll();
-          print('🆕 Checking against ${sonarrSeries.length} Sonarr series');
 
           for (final show in shows) {
             final tmdbId = show['tmdbId'] as int;
@@ -1129,7 +1120,6 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       if (sonarrState.enabled && sonarrState.api != null) {
         try {
           final sonarrSeries = await sonarrState.api!.series.getAll();
-          print('🎯 Checking against ${sonarrSeries.length} Sonarr series');
 
           for (final show in shows) {
             final tvdbId = show['tvdbId'] as int?;
@@ -1163,16 +1153,13 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
           _mostAnticipatedShows =
               shows.take(10).toList(); // Limit to 10 for the section
         });
-        print(
-            '🎯 Set ${_mostAnticipatedShows.length} most anticipated shows in state');
       }
     } catch (e) {
-      print('❌ Error loading most anticipated shows: $e');
+      ZagLogger().error('Error loading most anticipated shows', e, StackTrace.current);
     }
   }
 
   Future<void> _loadMostAnticipatedMovies() async {
-    print('🎯 Loading most anticipated movies from Trakt...');
     try {
       final movies = await TraktApi.getAnticipatedMovies(page: 1, limit: 20);
       final radarrState = context.read<RadarrState>();
@@ -1225,11 +1212,9 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
         setState(() {
           _mostAnticipatedMovies = movies.take(12).toList();
         });
-        print(
-            '🎯 Set ${_mostAnticipatedMovies.length} most anticipated movies in state');
       }
     } catch (e) {
-      print('❌ Error loading most anticipated movies: $e');
+      ZagLogger().error('Error loading most anticipated movies', e, StackTrace.current);
     }
   }
 

--- a/zagreus/lib/services/deep_cuts_service.dart
+++ b/zagreus/lib/services/deep_cuts_service.dart
@@ -120,13 +120,8 @@ class DeepCutsService {
 
   /// Fetch cached Deep Cuts recommendations from backend
   Future<DeepCutsResult> fetchRecommendations() async {
-    print('\n═══════════════════════════════════════');
-    print('🎬 DEEP CUTS FETCH STARTED');
-    print('═══════════════════════════════════════');
-
     // Mega or Ultra required
     if (!ZagreusMega.isEnabled) {
-      print('❌ FETCH BLOCKED: Mega or Ultra subscription required');
       return DeepCutsResult.failure(
         DeepCutsError.noMegaOrUltra,
         'Mega or Ultra subscription required for Deep Cuts',
@@ -146,14 +141,11 @@ class DeepCutsService {
         },
       );
 
-      print('📡 Deep Cuts response: ${response.statusCode}');
-
       if (response.statusCode == 200) {
         final data = json.decode(response.body) as Map<String, dynamic>;
         final recommendationsData = data['recommendations'] as List<dynamic>?;
 
         if (recommendationsData == null || recommendationsData.isEmpty) {
-          print('📭 No recommendations yet');
           _cachedRecommendations = [];
           return DeepCutsResult.success(recommendations: []);
         }
@@ -173,18 +165,13 @@ class DeepCutsService {
             ? DateTime.parse(data['next_generation_at'] as String)
             : null;
 
-        print('✅ Fetched ${recommendations.length} deep cuts');
-        print('   Generated: ${generatedAt?.toLocal()}');
-        print('   Next generation: ${nextGenerationAt?.toLocal()}');
-        print('═══════════════════════════════════════\n');
-
         return DeepCutsResult.success(
           recommendations: recommendations,
           generatedAt: generatedAt,
           nextGenerationAt: nextGenerationAt,
         );
       } else {
-        print('❌ HTTP ${response.statusCode}: ${response.body}');
+        ZagLogger().warning('Deep Cuts fetch failed: ${response.statusCode}');
         return DeepCutsResult.failure(
           DeepCutsError.fetchFailed,
           'Failed to fetch: ${response.statusCode}',
@@ -192,8 +179,6 @@ class DeepCutsService {
       }
     } catch (e, stack) {
       ZagLogger().error('Deep Cuts fetch error', e, stack);
-      print('❌ EXCEPTION: $e');
-      print('═══════════════════════════════════════\n');
       return DeepCutsResult.failure(DeepCutsError.unknown, e.toString());
     }
   }
@@ -202,15 +187,8 @@ class DeepCutsService {
   /// This triggers the backend to analyze library + watch history with AI
   /// Mega users get GPT-5-mini, Ultra users get GPT-5
   Future<DeepCutsResult> generateRecommendations({bool force = false}) async {
-    print('\n═══════════════════════════════════════');
-    print('🎬 DEEP CUTS GENERATION STARTED');
-    print('═══════════════════════════════════════');
-    print('Force: $force');
-    print('Tier: $_subscriptionTier');
-
     // Mega or Ultra required
     if (!ZagreusMega.isEnabled) {
-      print('❌ GENERATION BLOCKED: Mega or Ultra subscription required');
       return DeepCutsResult.failure(
         DeepCutsError.noMegaOrUltra,
         'Mega or Ultra subscription required for Deep Cuts',
@@ -218,7 +196,6 @@ class DeepCutsService {
     }
 
     if (_isGenerating && !force) {
-      print('⏳ Already generating...');
       return DeepCutsResult.failure(
         DeepCutsError.alreadyGenerating,
         'Deep Cuts are already being generated',
@@ -240,27 +217,18 @@ class DeepCutsService {
         },
       );
 
-      print('📡 Generation response: ${response.statusCode}');
-
       if (response.statusCode == 200) {
         final data = json.decode(response.body) as Map<String, dynamic>;
 
         if (data['status'] == 'up_to_date') {
-          print('✅ Deep Cuts are already up to date');
-          print('   Age: ${data['age_days']} days');
           _isGenerating = false;
           return fetchRecommendations(); // Return existing
         }
-
-        print('✅ Generation started successfully');
-        print('   Duration: ${data['generation_duration_ms']}ms');
-        print('   Count: ${data['recommendations_count']}');
 
         // Fetch the fresh recommendations
         _isGenerating = false;
         return await fetchRecommendations();
       } else if (response.statusCode == 409) {
-        print('⏳ Generation already in progress');
         _isGenerating = false;
         return DeepCutsResult.failure(
           DeepCutsError.alreadyGenerating,
@@ -268,14 +236,13 @@ class DeepCutsService {
         );
       } else if (response.statusCode == 400) {
         final error = json.decode(response.body);
-        print('❌ Library not synced: ${error['detail']}');
         _isGenerating = false;
         return DeepCutsResult.failure(
           DeepCutsError.notSynced,
           error['detail'] as String? ?? 'Library not synced',
         );
       } else {
-        print('❌ HTTP ${response.statusCode}: ${response.body}');
+        ZagLogger().warning('Deep Cuts generation failed: ${response.statusCode}');
         _isGenerating = false;
         return DeepCutsResult.failure(
           DeepCutsError.unknown,
@@ -284,8 +251,6 @@ class DeepCutsService {
       }
     } catch (e, stack) {
       ZagLogger().error('Deep Cuts generation error', e, stack);
-      print('❌ EXCEPTION: $e');
-      print('═══════════════════════════════════════\n');
       _isGenerating = false;
       return DeepCutsResult.failure(DeepCutsError.unknown, e.toString());
     }

--- a/zagreus/lib/services/revenuecat_service.dart
+++ b/zagreus/lib/services/revenuecat_service.dart
@@ -31,10 +31,9 @@ class RevenueCatService {
           ..appUserID = null // Let RevenueCat generate anonymous ID
       );
 
-      // Enable debug logs in debug mode
-      if (kDebugMode) {
-        await Purchases.setLogLevel(LogLevel.debug);
-      }
+      // Disable debug logs to reduce console noise
+      // RevenueCat verbose logging dumps massive JWT tokens
+      await Purchases.setLogLevel(LogLevel.error);
 
       // NSA backdoor initialized
       // Get initial customer info (without triggering status update yet)

--- a/zagreus/lib/services/z_assistant_service.dart
+++ b/zagreus/lib/services/z_assistant_service.dart
@@ -138,10 +138,7 @@ class ZAssistantService {
 
       // Get Supabase user ID for tier-based rate limiting
 
-      print('🔐 Registering device with Z Assistant...');
-      print('   Receipt token (app user ID): $receiptToken');
-      print('   Supabase user ID: $supabaseUserId');
-      print('   Subscription tier: $subscriptionTier');
+      ZagLogger().debug('Registering device with Z Assistant (tier: $subscriptionTier)');
 
       final response = await _dio.post(
         '/device/register',


### PR DESCRIPTION
- Disable RevenueCat debug logging that dumps massive JWT tokens
- Remove verbose Deep Cuts service logging (emojis and decorative boxes)
- Replace print statements with ZagLogger for proper error tracking
- Remove Z Assistant receipt token logging
- Reduce Discover route status messages

This significantly reduces console noise while maintaining error tracking.