### PR TITLE
Fix excessive error logging output

### DIFF
--- a/zagreus/lib/services/revenuecat_service.dart
+++ b/zagreus/lib/services/revenuecat_service.dart
@@ -31,9 +31,9 @@ class RevenueCatService {
           ..appUserID = null // Let RevenueCat generate anonymous ID
       );
 
-      // Enable debug logs in debug mode
+      // Enable minimal logging in debug mode to avoid JWT token spam
       if (kDebugMode) {
-        await Purchases.setLogLevel(LogLevel.debug);
+        await Purchases.setLogLevel(LogLevel.info);
       }
 
       // NSA backdoor initialized

--- a/zagreus/lib/services/z_assistant_service.dart
+++ b/zagreus/lib/services/z_assistant_service.dart
@@ -139,8 +139,8 @@ class ZAssistantService {
       // Get Supabase user ID for tier-based rate limiting
 
       print('🔐 Registering device with Z Assistant...');
-      print('   Receipt token (app user ID): $receiptToken');
-      print('   Supabase user ID: $supabaseUserId');
+      print('   Receipt token length: ${receiptToken.length} chars');
+      print('   Supabase user ID: ${supabaseUserId != null ? "present" : "none"}');
       print('   Subscription tier: $subscriptionTier');
 
       final response = await _dio.post(


### PR DESCRIPTION
- Reduce RevenueCat log level from debug to info to prevent transaction token spam
- Sanitize device registration logs to only show token length, not full value
- Prevents massive JWT strings from cluttering console output