### PR TITLE
Fix route memory saving/restoring when toggle is disabled

### DIFF
--- a/zagreus/lib/system/session_state.dart
+++ b/zagreus/lib/system/session_state.dart
@@ -29,11 +29,13 @@ class ZagSessionState {
 
   /// Get the last visited route for a module, or null if not set
   String? getModuleLastRoute(String moduleKey) {
+    if (!tabMemoryEnabled) return null;
     return _moduleLastRoutes[moduleKey];
   }
 
   /// Save the last visited route for a module
   void setModuleLastRoute(String moduleKey, String routePath) {
+    if (!tabMemoryEnabled) return;
     _moduleLastRoutes[moduleKey] = routePath;
     print('🔍 Session: Saved ${moduleKey} last route: $routePath');
   }


### PR DESCRIPTION
The previous fix only prevented _RouteLocationTracker from calling setModuleLastRoute, but that method was still saving routes anyway. Also, getModuleLastRoute was returning saved routes even when disabled.

This caused modules to restore to their last visited page even when "Remember Module Pages" was turned off.

Changes:
- setModuleLastRoute: Check tabMemoryEnabled before saving
- getModuleLastRoute: Check tabMemoryEnabled and return null if disabled

Now when the toggle is off:
1. Routes won't be saved at all
2. Even if old routes exist, they won't be returned
3. Modules will always navigate to their home page