### PR TITLE
Fix route tracking overwriting saved routes on cross-module navigation

### DIFF
--- a/zagreus/lib/router/router.dart
+++ b/zagreus/lib/router/router.dart
@@ -80,8 +80,26 @@ class _FABRouteObserver extends NavigatorObserver {
   void didPop(Route route, Route? previousRoute) {
     if (previousRoute != null) {
       _updateFAB(previousRoute);
-      _trackRoute(previousRoute);
+      // Only track the pop if we're staying within the same module
+      // Extract module from both routes
+      final poppedModule = _extractModuleFromRouteName(route.settings.name);
+      final targetModule = _extractModuleFromRouteName(previousRoute.settings.name);
+
+      // Only track if both routes are in the same module
+      if (poppedModule != null && poppedModule == targetModule) {
+        print('🔍 FABObserver: didPop within same module ($poppedModule), tracking');
+        _trackRoute(previousRoute);
+      } else {
+        print('🔍 FABObserver: didPop leaving module ($poppedModule → $targetModule), not tracking');
+      }
     }
+  }
+
+  String? _extractModuleFromRouteName(String? routeName) {
+    if (routeName == null || routeName.isEmpty) return null;
+    final parts = routeName.split(':');
+    if (parts.length < 2) return null;
+    return parts[0].toLowerCase();
   }
 
   @override


### PR DESCRIPTION
Only track didPop events that stay within the same module to avoid overwriting saved routes when navigating away via FAB. When using the Speed Cube to switch modules, the navigation stack pops back to home, and we were incorrectly saving that home route and overwriting the desired deep link (e.g., movie page).

Now checks if both the popped route and target route are in the same module before tracking the navigation. This preserves the intended behavior where leaving from a deep link and returning should restore that deep link, while still fixing the original bug where clicking back within a module didn't update the saved route.