### PR TITLE
Fix Lidarr album cover URLs on Server tab

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -7342,7 +7342,8 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
             String? coverUrl;
             try {
               // Construct cover URL from Lidarr API
-              coverUrl = '${ZagProfile.current.lidarrHost}/api/v1/mediacover/${record.albumID}/cover.jpg?apikey=${ZagProfile.current.lidarrKey}';
+              // Note: Lidarr uses /mediacover/Album/{albumId} for album covers
+              coverUrl = '${ZagProfile.current.lidarrHost}/api/v1/mediacover/Album/${record.albumID}/cover.jpg?apikey=${ZagProfile.current.lidarrKey}';
             } catch (e) {
               // Fallback to null if URL construction fails
               coverUrl = null;


### PR DESCRIPTION
The album cover URLs were missing the 'Album/' prefix in the media cover endpoint path. Lidarr's API structure requires the format: /api/v1/mediacover/Album/{albumId}/cover.jpg

Changed from:
  /api/v1/mediacover/{albumId}/cover.jpg

To:
  /api/v1/mediacover/Album/{albumId}/cover.jpg

This fixes album covers not loading in the Recently Downloaded Albums section on the Server tab.