### PR TITLE
Fix route memory: Track both from and to modules for bounce-back

### DIFF
--- a/zagreus/lib/widgets/ui/global_fab_overlay.dart
+++ b/zagreus/lib/widgets/ui/global_fab_overlay.dart
@@ -104,7 +104,8 @@ class ZagGlobalFABManager {
   void trackModuleLaunch(String targetModuleKey) {
     print('🔍 FABManager: trackModuleLaunch called for: $targetModuleKey');
     // Forward to the FAB's static tracking method
-    ZagSpeedCube.updateModuleTracking(targetModuleKey);
+    final fromModule = _currentModule; // Track where we're coming from
+    ZagSpeedCube.updateModuleTracking(fromModule, targetModuleKey);
   }
 
   String _extractModuleFromRoute(String route) {

--- a/zagreus/lib/widgets/ui/speed_cube.dart
+++ b/zagreus/lib/widgets/ui/speed_cube.dart
@@ -13,8 +13,8 @@ class ZagSpeedCube extends StatefulWidget {
   }) : super(key: key);
 
   // Public static method accessible from outside
-  static void updateModuleTracking(String moduleKey) {
-    _ZagSpeedCubeState._updateTracking(moduleKey);
+  static void updateModuleTracking(String fromModule, String toModule) {
+    _ZagSpeedCubeState._updateTracking(fromModule, toModule);
   }
 
   @override
@@ -33,11 +33,11 @@ class _ZagSpeedCubeState extends State<ZagSpeedCube>
   static String? _previousModuleKey;
 
   // Internal tracking method
-  static void _updateTracking(String moduleKey) {
-    _previousModuleKey = _lastLaunchedModuleKey;
-    _lastLaunchedModuleKey = moduleKey;
+  static void _updateTracking(String fromModule, String toModule) {
+    _previousModuleKey = fromModule;
+    _lastLaunchedModuleKey = toModule;
     print(
-        '🔍 FAB: Tracking updated! Previous: $_previousModuleKey, Current: $moduleKey');
+        '🔍 FAB: Tracking updated! Previous: $_previousModuleKey, Current: $toModule');
   }
 
   @override
@@ -339,8 +339,8 @@ class _ZagSpeedCubeState extends State<ZagSpeedCube>
               await module.launch(restore: false);
               print('🔍 FAB: module.launch() completed successfully');
 
-              // Use the internal tracking method
-              _updateTracking(module.key);
+              // Track that we're switching from current module to new module
+              _updateTracking(widget.currentModuleKey, module.key);
             } catch (e, stack) {
               print('🔍 FAB: ERROR during launch: $e');
               print('🔍 FAB: Stack trace: $stack');


### PR DESCRIPTION
Changed _updateTracking to take two parameters (fromModule, toModule) instead of just the target module. This ensures the 'previous' module is correctly set when navigating.

Before: Previous was always null on first navigation
After: Previous is set to the module you're leaving from

Now when you go Radarr → Sonarr via cube, the tracking correctly sets:
- Previous: radarr (so you can bounce back)
- Current: sonarr (where you are now)