### PR TITLE
Re-enable RouteLocationTracker for live route tracking

### DIFF
--- a/zagreus/lib/router/router.dart
+++ b/zagreus/lib/router/router.dart
@@ -24,8 +24,9 @@ class ZagRouter {
         _FABRouteObserver(), // Track routes for global FAB
       ],
     );
-    // Route tracking is now handled manually in Speed Cube long-press
-    // _routeTracker = _RouteLocationTracker(router.routeInformationProvider);
+    // Route tracking saves routes as you navigate (for bounce-back feature)
+    // Restoration is controlled by module.launch(restore: true/false)
+    _routeTracker = _RouteLocationTracker(router.routeInformationProvider);
   }
 
   void popSafely() {

--- a/zagreus/lib/widgets/ui/speed_cube.dart
+++ b/zagreus/lib/widgets/ui/speed_cube.dart
@@ -324,16 +324,7 @@ class _ZagSpeedCubeState extends State<ZagSpeedCube>
 
             await Future.delayed(const Duration(milliseconds: 100));
 
-            // Save current route before leaving for bounce-back feature
-            final currentLocation = ZagRouter.router.routeInformationProvider.value.location;
-            if (currentLocation != null && currentLocation.isNotEmpty) {
-              final currentModule = widget.currentModuleKey;
-              if (currentModule.isNotEmpty) {
-                ZagSessionState.instance.setModuleLastRoute(currentModule, currentLocation);
-                print('🔍 FAB: Saved current route for future bounce-back: $currentLocation');
-              }
-            }
-
+            // Route saving is handled automatically by _RouteLocationTracker
             print('🔍 FAB: Calling module.launch(restore: false)...');
             try {
               await module.launch(restore: false);


### PR DESCRIPTION
Chesterton's fence was right! The _RouteLocationTracker wasn't just sitting there - it was actively listening to route changes and saving them as you navigate. Without it, when you tap the cube menu from a movie page, we read the router location and get /radarr instead of /radarr/movie/505 because the navigation hasn't been tracked.

Changes:
1. Re-enabled _RouteLocationTracker to save routes as you navigate
2. Removed manual route saving from cube tap (now handled by tracker)
3. Separation of concerns:
   - _RouteLocationTracker: SAVES routes automatically
   - module.launch(restore: true/false): Controls RESTORATION

This fixes the issue where long-press wasn't restoring the movie page because the movie route was never being tracked in the first place.