### PR TITLE
Invert module tab visibility toggle default

### DIFF
--- a/zagreus/lib/database/tables/zagreus.dart
+++ b/zagreus/lib/database/tables/zagreus.dart
@@ -114,7 +114,7 @@ enum ZagreusDatabase<T> with ZagTableMixin<T> {
   DISCOVER_MONOCHROME_RATINGS<bool>(false),
   DISCOVER_TRENDING_TIME_WINDOW<String>('day'),
   DISCOVER_DEFAULT_TAB<String>('movies'),
-  SHOW_LEGACY_MODULES_TAB<bool>(false),
+  SHOW_LEGACY_MODULES_TAB<bool>(true),
   SHOW_AGENT_TAB<bool>(true);
 
   @override

--- a/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
@@ -133,20 +133,20 @@ class _State extends State<ConfigurationNavigationRoute>
     const db = ZagreusDatabase.SHOW_LEGACY_MODULES_TAB;
     return db.listenableBuilder(
       builder: (context, _) => ZagBlock(
-        title: 'Show Modules Tab',
+        title: 'Hide Modules Tab',
         body: const [
           TextSpan(
-            text: 'Restores Modules tab in Dashboard.',
+            text: 'Hides Modules tab in Dashboard.',
           ),
         ],
         trailing: ZagSwitch(
-          value: db.read(),
+          value: !db.read(),
           onChanged: (value) {
-            db.update(value);
-            if (!value &&
+            db.update(!value);
+            if (value &&
                 ZagreusDatabase.DISCOVER_DEFAULT_TAB.read() == 'modules') {
               ZagreusDatabase.DISCOVER_DEFAULT_TAB.update('movies');
-            } else if (value) {
+            } else if (!value) {
               ZagreusDatabase.DISCOVER_DEFAULT_TAB.update('modules');
             }
           },


### PR DESCRIPTION
Changes the module tab behavior from opt-in to opt-out:
- Module tab now shown by default (SHOW_LEGACY_MODULES_TAB = true)
- Toggle renamed from "Show Modules Tab" to "Hide Modules Tab"
- Toggle logic inverted: ON hides the tab, OFF shows it
- Default tab logic updated to match new behavior