### PR TITLE
Update Radarr crew list with modern people component

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/cast_crew_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/cast_crew_tile.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/core.dart';
-import 'package:zagreus/extensions/string/links.dart';
 import 'package:zagreus/modules/radarr.dart';
+import 'package:zagreus/modules/discover/routes/person_details/route.dart';
 
 class RadarrMovieDetailsCastCrewTile extends StatelessWidget {
   final RadarrMovieCredits credits;
@@ -29,7 +29,18 @@ class RadarrMovieDetailsCastCrewTile extends StatelessWidget {
           ),
         ),
       ],
-      onTap: credits.personTmdbId?.toString().openTmdbPerson,
+      onTap: credits.personTmdbId != null
+          ? () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => PersonDetailsRoute(
+                    personId: credits.personTmdbId!,
+                    personName: credits.personName ?? '',
+                  ),
+                ),
+              );
+            }
+          : null,
     );
   }
 


### PR DESCRIPTION
Replace external TMDB links with internal PersonDetailsRoute navigation for cast and crew members in Radarr movie details. This provides users with a richer experience including filmography browsing and quick access to add movies/shows from the person's credits.

Changes:
- Navigate to PersonDetailsRoute instead of opening TMDB in browser
- Maintain existing poster/icon size and styling
- Keep placeholder icon (ZagIcons.USER) for consistency