### PR TITLE
Fix cast/crew profile images by using remoteUrl

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/cast_crew_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/cast_crew_tile.dart
@@ -16,7 +16,9 @@ class RadarrMovieDetailsCastCrewTile extends StatelessWidget {
     return ZagBlock(
       title: credits.personName,
       posterPlaceholderIcon: ZagIcons.USER,
-      posterUrl: credits.images!.isEmpty ? null : credits.images![0].url,
+      posterUrl: credits.images!.isEmpty
+          ? null
+          : (credits.images![0].remoteUrl ?? credits.images![0].url),
       body: [
         TextSpan(text: _position),
         TextSpan(


### PR DESCRIPTION
Use remoteUrl with url fallback for profile images in Radarr cast/crew list, matching the pattern used throughout the codebase. This fixes the broken icons that were showing placeholder images instead of actual profile photos.