### PR TITLE
Show movie posters in Radarr missing tab

### DIFF
--- a/zagreus/lib/modules/radarr/routes/missing/widgets/missing_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/missing/widgets/missing_tile.dart
@@ -35,9 +35,10 @@ class _State extends State<RadarrMissingTile> {
       builder: (context, missing, _) => ZagBlock(
         backgroundUrl:
             context.read<RadarrState>().getFanartURL(widget.movie.id),
-        posterUrl: null, // Don't show posters on missing movies
+        posterUrl: context.read<RadarrState>().getPosterURL(widget.movie.id),
         posterHeaders: context.read<RadarrState>().headers,
         posterPlaceholderIcon: ZagIcons.VIDEO_CAM,
+        posterIsSquare: false,
         disabled: !widget.movie.monitored!,
         title: widget.movie.title,
         body: [


### PR DESCRIPTION
Enable poster display in missing movies list to match the visual consistency of upcoming and catalogue tabs. Missing movies now show their poster thumbnails alongside fanart backgrounds instead of just placeholder icons.