### PR TITLE
Add cast & crew functionality to Sonarr series details

### DIFF
--- a/zagreus/lib/api/sonarr/models.dart
+++ b/zagreus/lib/api/sonarr/models.dart
@@ -60,6 +60,7 @@ export 'models/root_folder/unmapped_folder.dart';
 
 /// Series
 export 'models/series/alternate_title.dart';
+export 'models/series/credits.dart';
 export 'models/series/image.dart';
 export 'models/series/rating.dart';
 export 'models/series/season_statistics.dart';

--- a/zagreus/lib/api/sonarr/models/series/credits.dart
+++ b/zagreus/lib/api/sonarr/models/series/credits.dart
@@ -1,0 +1,76 @@
+/// Store details about credits for a person who has worked on the series.
+///
+/// Unlike Radarr which gets credits from its API, Sonarr credits come from
+/// TMDB API since Sonarr doesn't have a native credits endpoint.
+class SonarrSeriesCredits {
+  /// Person's name
+  String? personName;
+
+  /// TMDB person ID (for linking to person details)
+  int? personTmdbId;
+
+  /// Character name (for cast members)
+  String? character;
+
+  /// Job title (for crew members)
+  String? job;
+
+  /// Department (for crew members)
+  String? department;
+
+  /// Type: 'cast' or 'crew'
+  String? type;
+
+  /// Display order (lower numbers appear first)
+  int? order;
+
+  /// TMDB profile image path (e.g., '/j7d083zIMhwnKro3tQqDz2Fq1UD.jpg')
+  String? profilePath;
+
+  /// Associated series ID
+  int? seriesId;
+
+  SonarrSeriesCredits({
+    this.personName,
+    this.personTmdbId,
+    this.character,
+    this.job,
+    this.department,
+    this.type,
+    this.order,
+    this.profilePath,
+    this.seriesId,
+  });
+
+  /// Create from TMDB cast member data
+  factory SonarrSeriesCredits.fromTmdbCast(
+    Map<String, dynamic> json,
+    int seriesId,
+  ) {
+    return SonarrSeriesCredits(
+      personName: json['name'],
+      personTmdbId: json['id'],
+      character: json['character'],
+      type: 'cast',
+      order: json['order'],
+      profilePath: json['profile_path'],
+      seriesId: seriesId,
+    );
+  }
+
+  /// Create from TMDB crew member data
+  factory SonarrSeriesCredits.fromTmdbCrew(
+    Map<String, dynamic> json,
+    int seriesId,
+  ) {
+    return SonarrSeriesCredits(
+      personName: json['name'],
+      personTmdbId: json['id'],
+      job: json['job'],
+      department: json['department'],
+      type: 'crew',
+      profilePath: json['profile_path'],
+      seriesId: seriesId,
+    );
+  }
+}

--- a/zagreus/lib/modules/discover/core/tmdb_api.dart
+++ b/zagreus/lib/modules/discover/core/tmdb_api.dart
@@ -570,6 +570,57 @@ class TMDBApi {
     }
   }
 
+  /// Get TMDB ID from IMDb ID for TV shows
+  /// Used for Sonarr series that have IMDb IDs but not TMDB IDs
+  static Future<int?> getTmdbIdFromImdb(String imdbId) async {
+    try {
+      final response = await http.get(
+        Uri.parse(
+            '$_baseUrl/find/$imdbId?external_source=imdb_id&api_key=$_apiKey'),
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final tvResults = data['tv_results'] as List;
+
+        // Only proceed if exactly 1 result to avoid ambiguity
+        if (tvResults.length == 1) {
+          return tvResults[0]['id'] as int;
+        }
+
+        // Multiple or zero results = can't determine correct show
+        return null;
+      }
+
+      return null;
+    } catch (e) {
+      print('TMDB API Error (IMDb Lookup): $e');
+      return null;
+    }
+  }
+
+  /// Get TV show credits (cast and crew) from TMDB
+  static Future<Map<String, dynamic>?> getTvCredits(int tmdbId) async {
+    try {
+      final response = await http.get(
+        Uri.parse('$_baseUrl/tv/$tmdbId/credits?api_key=$_apiKey'),
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        return {
+          'cast': data['cast'] as List,
+          'crew': data['crew'] as List,
+        };
+      }
+
+      return null;
+    } catch (e) {
+      print('TMDB API Error (TV Credits): $e');
+      return null;
+    }
+  }
+
   static String? _extractYear(String? dateString) {
     if (dateString == null || dateString.isEmpty) return null;
     return dateString.split('-').first;

--- a/zagreus/lib/modules/sonarr/routes/series_details/route.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/route.dart
@@ -194,6 +194,7 @@ class _State extends State<SeriesDetailsRoute> with ZagLoadCallbackMixin {
           ),
           SonarrSeriesDetailsSeasonsPage(series: series),
           const SonarrSeriesDetailsHistoryPage(),
+          SonarrSeriesDetailsCastCrewPage(series: series),
         ],
       ),
     );

--- a/zagreus/lib/modules/sonarr/routes/series_details/state.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/state.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/core.dart';
 import 'package:zagreus/modules/sonarr.dart';
+import 'package:zagreus/modules/discover/core/tmdb_api.dart';
 
 class SonarrSeriesDetailsState extends ChangeNotifier {
   final SonarrSeries series;
@@ -10,6 +11,7 @@ class SonarrSeriesDetailsState extends ChangeNotifier {
     required this.series,
   }) {
     fetchHistory(context);
+    fetchCredits(context);
   }
 
   Future<void> fetchHistory(BuildContext context) async {
@@ -26,4 +28,67 @@ class SonarrSeriesDetailsState extends ChangeNotifier {
 
   Future<List<SonarrHistoryRecord>>? _history;
   Future<List<SonarrHistoryRecord>>? get history => _history;
+
+  Future<List<SonarrSeriesCredits>>? _credits;
+  Future<List<SonarrSeriesCredits>>? get credits => _credits;
+
+  Future<void> fetchCredits(BuildContext context) async {
+    try {
+      // Step 1: Check if series has IMDb ID
+      if (series.imdbId == null || series.imdbId!.isEmpty) {
+        ZagLogger().warning(
+          'No IMDb ID for series: ${series.title}',
+        );
+        return;
+      }
+
+      // Step 2: Get TMDB ID from IMDb ID
+      final tmdbId = await TMDBApi.getTmdbIdFromImdb(series.imdbId!);
+
+      if (tmdbId == null) {
+        ZagLogger().warning(
+          'Could not find TMDB ID for series: ${series.title} (IMDb: ${series.imdbId})',
+        );
+        return;
+      }
+
+      // Step 3: Fetch credits from TMDB
+      final creditsData = await TMDBApi.getTvCredits(tmdbId);
+
+      if (creditsData == null) {
+        ZagLogger().warning(
+          'Could not fetch credits for series: ${series.title} (TMDB ID: $tmdbId)',
+        );
+        return;
+      }
+
+      // Step 4: Parse and store credits
+      final List<SonarrSeriesCredits> creditsList = [];
+
+      // Parse cast members
+      final castList = creditsData['cast'] as List;
+      for (final castMember in castList) {
+        creditsList.add(
+          SonarrSeriesCredits.fromTmdbCast(castMember, series.id!),
+        );
+      }
+
+      // Parse crew members (optional - uncomment if you want crew support)
+      // final crewList = creditsData['crew'] as List;
+      // for (final crewMember in crewList) {
+      //   creditsList.add(
+      //     SonarrSeriesCredits.fromTmdbCrew(crewMember, series.id!),
+      //   );
+      // }
+
+      _credits = Future.value(creditsList);
+      notifyListeners();
+    } catch (error, stack) {
+      ZagLogger().error(
+        'Error fetching credits for ${series.title}',
+        error,
+        stack,
+      );
+    }
+  }
 }

--- a/zagreus/lib/modules/sonarr/routes/series_details/widgets.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/widgets.dart
@@ -1,7 +1,9 @@
 export 'widgets/appbar_settings_action.dart';
+export 'widgets/cast_crew_tile.dart';
 export 'widgets/navigation_bar.dart';
 export 'widgets/overview_series_description_tile.dart';
 export 'widgets/overview_series_information_block.dart.dart';
+export 'widgets/page_cast_crew.dart';
 export 'widgets/page_history.dart';
 export 'widgets/page_overview.dart';
 export 'widgets/page_seasons.dart';

--- a/zagreus/lib/modules/sonarr/routes/series_details/widgets/cast_crew_tile.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/widgets/cast_crew_tile.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:zagreus/core.dart';
+import 'package:zagreus/modules/sonarr.dart';
+import 'package:zagreus/modules/discover/routes/person_details/route.dart';
+import 'package:zagreus/modules/discover/core/tmdb_api.dart';
+
+class SonarrSeriesDetailsCastCrewTile extends StatelessWidget {
+  final SonarrSeriesCredits credits;
+
+  const SonarrSeriesDetailsCastCrewTile({
+    Key? key,
+    required this.credits,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ZagBlock(
+      title: credits.personName,
+      posterPlaceholderIcon: ZagIcons.USER,
+      posterUrl: TMDBApi.getImageUrl(credits.profilePath, size: 'w185'),
+      body: [
+        TextSpan(text: _position),
+        TextSpan(
+          text: credits.type == 'cast' ? 'Cast' : 'Crew',
+          style: TextStyle(
+            fontWeight: ZagUI.FONT_WEIGHT_BOLD,
+            color: credits.type == 'cast'
+                ? ZagColours.accent
+                : ZagColours.orange,
+          ),
+        ),
+      ],
+      onTap: credits.personTmdbId != null
+          ? () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => PersonDetailsRoute(
+                    personId: credits.personTmdbId!,
+                    personName: credits.personName ?? '',
+                  ),
+                ),
+              );
+            }
+          : null,
+    );
+  }
+
+  String? get _position {
+    if (credits.type == 'cast') {
+      return credits.character?.isEmpty ?? true
+          ? ZagUI.TEXT_EMDASH
+          : credits.character;
+    } else {
+      return credits.job?.isEmpty ?? true ? ZagUI.TEXT_EMDASH : credits.job;
+    }
+  }
+}

--- a/zagreus/lib/modules/sonarr/routes/series_details/widgets/navigation_bar.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/widgets/navigation_bar.dart
@@ -9,12 +9,14 @@ class SonarrSeriesDetailsNavigationBar extends StatelessWidget {
     Icons.subject_rounded,
     Icons.live_tv_rounded,
     Icons.history_rounded,
+    Icons.people_rounded,
   ];
 
   static final List<String> titles = [
     'sonarr.Overview'.tr(),
     'sonarr.Seasons'.tr(),
     'sonarr.History'.tr(),
+    'Cast & Crew',
   ];
 
   final PageController? pageController;

--- a/zagreus/lib/modules/sonarr/routes/series_details/widgets/page_cast_crew.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/widgets/page_cast_crew.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:zagreus/core.dart';
+import 'package:zagreus/modules/sonarr.dart';
+import 'package:zagreus/modules/sonarr/routes/series_details/widgets/cast_crew_tile.dart';
+
+class SonarrSeriesDetailsCastCrewPage extends StatefulWidget {
+  final SonarrSeries? series;
+
+  const SonarrSeriesDetailsCastCrewPage({
+    Key? key,
+    required this.series,
+  }) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _State();
+}
+
+class _State extends State<SonarrSeriesDetailsCastCrewPage>
+    with AutomaticKeepAliveClientMixin {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  final GlobalKey<RefreshIndicatorState> _refreshKey =
+      GlobalKey<RefreshIndicatorState>();
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return ZagScaffold(
+      module: ZagModule.SONARR,
+      scaffoldKey: _scaffoldKey,
+      body: _body(),
+    );
+  }
+
+  Widget _body() {
+    return ZagRefreshIndicator(
+      context: context,
+      key: _refreshKey,
+      onRefresh: () async =>
+          context.read<SonarrSeriesDetailsState>().fetchCredits(context),
+      child: FutureBuilder(
+        future: context.watch<SonarrSeriesDetailsState>().credits,
+        builder: (context, AsyncSnapshot<List<SonarrSeriesCredits>> snapshot) {
+          if (snapshot.hasError) {
+            ZagLogger().error(
+                'Unable to fetch Sonarr credit/crew list: ${widget.series!.id}',
+                snapshot.error,
+                snapshot.stackTrace);
+            return ZagMessage.error(onTap: _refreshKey.currentState!.show);
+          }
+          if (snapshot.hasData) return _list(snapshot.data);
+          return const ZagLoader();
+        },
+      ),
+    );
+  }
+
+  Widget _list(List<SonarrSeriesCredits>? credits) {
+    if ((credits?.length ?? 0) == 0)
+      return ZagMessage(
+        text: 'No Credits Found',
+        buttonText: 'Refresh',
+        onTap: _refreshKey.currentState!.show,
+      );
+    List<SonarrSeriesCredits> _cast =
+        credits!.where((credit) => credit.type == 'cast').toList();
+    List<SonarrSeriesCredits> _crew =
+        credits.where((credit) => credit.type == 'crew').toList();
+    return ZagListView(
+      controller: SonarrSeriesDetailsNavigationBar.scrollControllers[3],
+      children: [
+        ...List.generate(
+            _cast.length,
+            (index) =>
+                SonarrSeriesDetailsCastCrewTile(credits: _cast[index])),
+        ...List.generate(
+            _crew.length,
+            (index) =>
+                SonarrSeriesDetailsCastCrewTile(credits: _crew[index])),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Implement complete cast and crew display for Sonarr series using TMDB API, matching the existing Radarr implementation pattern. Since Sonarr doesn't have a native credits endpoint, credits are fetched via TMDB using the series' IMDb ID.

Changes:
- Add TMDB API methods for IMDb→TMDB ID lookup and TV credits fetching
- Create SonarrSeriesCredits model for storing cast/crew data
- Add credits state management to SonarrSeriesDetailsState with automatic fetching on series details load
- Create cast/crew page widget with refresh support
- Create cast/crew tile widget with person detail navigation
- Add Cast & Crew tab to series details navigation bar
- Integrate cast/crew page into series details PageView

Features:
- Click cast/crew members to view their full filmography
- Uses existing PersonDetailsRoute for consistent UX
- Profile images loaded from TMDB with placeholder fallback
- Differentiates cast (blue) and crew (orange) with color coding
- Gracefully handles series without IMDb IDs or TMDB matches