### PR TITLE
Fix Readarr downloads drawer and app icon

### DIFF
--- a/zagreus/lib/modules/readarr/routes/readarr.dart
+++ b/zagreus/lib/modules/readarr/routes/readarr.dart
@@ -116,6 +116,11 @@ class _State extends State<ReadarrRoute> {
           icon: Icons.add_rounded,
           onPressed: () async => _enterAddAuthor(),
         ),
+        if (ZagreusDatabase.DOWNLOADS_DRAWER_ENABLED.read())
+          ZagIconButton(
+            icon: Icons.download_rounded,
+            onPressed: _openQueueDrawer,
+          ),
         ZagIconButton(
           icon: Icons.more_vert_rounded,
           onPressed: () async => _handlePopup(),
@@ -189,6 +194,13 @@ class _State extends State<ReadarrRoute> {
         default:
           ZagLogger().warning('Unknown Case: ${values[1]}');
       }
+  }
+
+  void _openQueueDrawer() {
+    final scaffoldState = _scaffoldKey.currentState;
+    if (scaffoldState?.hasEndDrawer ?? false) {
+      scaffoldState?.openEndDrawer();
+    }
   }
 
   void _refreshProfile() {

--- a/zagreus/lib/widgets/ui/global_cube_overlay.dart
+++ b/zagreus/lib/widgets/ui/global_cube_overlay.dart
@@ -118,6 +118,7 @@ class ZagGlobalCubeManager {
     if (routeLower.contains('sabnzbd')) return 'sabnzbd';
     if (routeLower.contains('nzbget')) return 'nzbget';
     if (routeLower.contains('overseerr')) return 'overseerr';
+    if (routeLower.contains('unraid')) return 'unraid';
     if (routeLower.contains('server')) return 'server';
     if (routeLower.contains('search')) return 'search';
     if (routeLower.contains('settings')) return '';


### PR DESCRIPTION
Adds an app bar action button for opening the queue drawer in Readarr module, shown only when DOWNLOADS_DRAWER_ENABLED is true. Also fixes speed cube not appearing in Unraid by adding 'unraid' to the module detection list.