### PR TITLE
Fix appbar_agent_action to use IconButton instead of ZagIconButton

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/widgets/appbar_agent_action.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/widgets/appbar_agent_action.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:zagreus/widgets/ui.dart';
 
 class DashboardAppBarAgentAction extends StatelessWidget {
   final VoidCallback onPressed;
@@ -11,11 +10,10 @@ class DashboardAppBarAgentAction extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ZagIconButton(
-      icon: Icons.smart_toy,
-      iconSize: ZagUI.ICON_SIZE,
-      onPressed: onPressed,
+    return IconButton(
+      icon: const Icon(Icons.smart_toy),
       tooltip: 'Z Agent',
+      onPressed: onPressed,
     );
   }
 }


### PR DESCRIPTION
ZagIconButton doesn't support tooltip parameter, so switching to regular IconButton which matches the pattern used in Discover module.