### PR TITLE
Fix Z Agent chat history persistence using Visibility widget

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
@@ -209,15 +209,20 @@ class _State extends State<DashboardRoute> {
       ),
     );
 
-    if (!_isAgentActive) return mainContent;
-
     return Stack(
       children: [
         mainContent,
         Positioned.fill(
-          child: KeyedSubtree(
-            key: const ValueKey('z_agent_overlay'),
-            child: const ZChatPage(),
+          child: Visibility(
+            visible: _isAgentActive,
+            maintainState: true,
+            child: Container(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              child: KeyedSubtree(
+                key: const ValueKey('z_agent_overlay'),
+                child: const ZChatPage(),
+              ),
+            ),
           ),
         ),
       ],


### PR DESCRIPTION
- Always keep ZChatPage in widget tree instead of conditionally removing it
- Use Visibility widget with maintainState: true to hide/show overlay
- Add Container with scaffold background color to match Discover pattern
- This prevents widget disposal and state loss when toggling the overlay

Now chat history will persist when closing and reopening the Z Agent.