### PR TITLE
Use Offstage widget to preserve Z Agent chat history

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
@@ -213,13 +213,12 @@ class _State extends State<DashboardRoute> {
       children: [
         mainContent,
         Positioned.fill(
-          child: Visibility(
-            visible: _isAgentActive,
-            maintainState: true,
+          child: Offstage(
+            offstage: !_isAgentActive,
             child: Container(
               color: Theme.of(context).scaffoldBackgroundColor,
               child: KeyedSubtree(
-                key: const ValueKey('z_agent_overlay'),
+                key: const ValueKey('dashboard_z_agent_overlay'),
                 child: const ZChatPage(),
               ),
             ),


### PR DESCRIPTION
- Replace Visibility with Offstage to keep ZChatPage in widget tree
- Offstage is more lightweight and designed for hiding widgets while maintaining state
- Keep Positioned.fill wrapper and Container with background color
- Update key to be more specific (dashboard_z_agent_overlay)

The Offstage widget prevents the child from being painted or hit-tested while keeping it in the tree, which should preserve all state including chat messages.