### PR TITLE
Restrict Search module to Pro and higher tiers

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/pages/modules.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/pages/modules.dart
@@ -143,5 +143,6 @@ class _State extends State<ModulesPage> with AutomaticKeepAliveClientMixin {
   bool _requiresPro(ZagModule module) =>
       module == ZagModule.DISCOVER ||
       module == ZagModule.OVERSEERR ||
+      module == ZagModule.SEARCH ||
       module == ZagModule.UNRAID;
 }

--- a/zagreus/lib/router/routes/search.dart
+++ b/zagreus/lib/router/routes/search.dart
@@ -6,6 +6,7 @@ import 'package:zagreus/modules/search/routes/results/route.dart';
 import 'package:zagreus/modules/search/routes/search/route.dart';
 import 'package:zagreus/modules/search/routes/subcategories/route.dart';
 import 'package:zagreus/router/routes.dart';
+import 'package:zagreus/utils/zagreus_pro.dart';
 import 'package:zagreus/vendor.dart';
 
 enum SearchRoutes with ZagRoutesMixin {
@@ -24,7 +25,7 @@ enum SearchRoutes with ZagRoutesMixin {
   ZagModule get module => ZagModule.SEARCH;
 
   @override
-  bool isModuleEnabled(BuildContext context) => true;
+  bool isModuleEnabled(BuildContext context) => ZagreusPro.isEnabled;
 
   @override
   GoRoute get routes {


### PR DESCRIPTION
This change aligns the Search module with other premium modules like Unraid, Overseerr, and Discover by requiring a Pro subscription tier (or higher) to access it.

Changes:
- Updated Search route to check ZagreusPro.isEnabled
- Added Search module to dashboard Pro tier filtering
- Added ZagreusPro import to search routes

The Search module is now restricted to Pro, Mega, and Ultra subscribers only.