### PR TITLE
Investigate interactive search UI across Radarr Sonarr Lidarr

### DIFF
--- a/zagreus/lib/api/radarr/commands/release/get_releases.dart
+++ b/zagreus/lib/api/radarr/commands/release/get_releases.dart
@@ -6,6 +6,7 @@ Future<List<RadarrRelease>> _commandGetReleases(
 }) async {
   Response response = await client.get('release', queryParameters: {
     'movieId': movieId,
+    'includeCustomFormats': true,
   });
   return (response.data as List)
       .map((release) => RadarrRelease.fromJson(release))

--- a/zagreus/lib/modules/radarr/routes/releases/widgets/release_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/releases/widgets/release_tile.dart
@@ -64,11 +64,23 @@ class _State extends State<RadarrReleasesTile> {
   }
 
   TextSpan _subtitle2() {
+    final hasCustomFormats = (widget.release.customFormats?.isNotEmpty ?? false) ||
+                             (widget.release.customFormatScore != null && widget.release.customFormatScore != 0);
     return TextSpan(
       children: [
         TextSpan(text: widget.release.zagQuality),
         TextSpan(text: ZagUI.TEXT_BULLET.pad()),
         TextSpan(text: widget.release.zagSize),
+        if (hasCustomFormats) ...[
+          TextSpan(text: ZagUI.TEXT_BULLET.pad()),
+          TextSpan(
+            text: widget.release.zagCustomFormatScore()!,
+            style: TextStyle(
+              color: ZagColours.blue,
+              fontWeight: ZagUI.FONT_WEIGHT_BOLD,
+            ),
+          ),
+        ],
       ],
     );
   }
@@ -79,14 +91,6 @@ class _State extends State<RadarrReleasesTile> {
         text: widget.release.protocol!.readable!,
         backgroundColor: widget.release.zagProtocolColor,
       ),
-      if (widget.release.zagCustomFormatScore(nullOnEmpty: true) != null)
-        ZagHighlightedNode(
-          text: widget.release.zagCustomFormatScore()!,
-          backgroundColor: ZagColours.purple,
-        ),
-      ...widget.release.customFormats!.map<ZagHighlightedNode>((custom) =>
-          ZagHighlightedNode(
-              text: custom.name!, backgroundColor: ZagColours.blueGrey)),
     ];
   }
 
@@ -103,6 +107,13 @@ class _State extends State<RadarrReleasesTile> {
                   .join('\n') ??
               ZagUI.TEXT_EMDASH),
       ZagTableContent(title: 'quality', body: widget.release.zagQuality),
+      if (widget.release.customFormats?.isNotEmpty ?? false)
+        ZagTableContent(
+          title: 'custom formats',
+          body: widget.release.customFormats!
+              .map<String>((format) => format.name ?? ZagUI.TEXT_EMDASH)
+              .join('\n'),
+        ),
       if (widget.release.seeders != null)
         ZagTableContent(title: 'seeders', body: '${widget.release.seeders}'),
       if (widget.release.leechers != null)


### PR DESCRIPTION
- Include custom formats in API call via includeCustomFormats parameter
- Display custom format score as blue badge in subtitle after file size
- Add custom formats field to expanded release view after quality field
- Remove redundant custom format highlighted nodes

This matches the nzb360 implementation where custom formats are shown conditionally when present, with the score prominently displayed in the collapsed view and the full list of formats available in the expanded view.