### PR TITLE
Set modules as default discover page for new users

### DIFF
--- a/zagreus/lib/database/tables/zagreus.dart
+++ b/zagreus/lib/database/tables/zagreus.dart
@@ -116,7 +116,7 @@ enum ZagreusDatabase<T> with ZagTableMixin<T> {
   DISCOVER_SHOW_TITLES<bool>(true),
   DISCOVER_MONOCHROME_RATINGS<bool>(false),
   DISCOVER_TRENDING_TIME_WINDOW<String>('day'),
-  DISCOVER_DEFAULT_TAB<String>('movies'),
+  DISCOVER_DEFAULT_TAB<String>('modules'),
   SHOW_LEGACY_MODULES_TAB<bool>(true),
   SHOW_AGENT_TAB<bool>(true);
 


### PR DESCRIPTION
Changed DISCOVER_DEFAULT_TAB from 'movies' to 'modules' to ensure new users land on the modules page by default when accessing the Discover module.