### PR TITLE
Fix custom format score sorting direction and translation

### DIFF
--- a/zagreus/assets/localization/en.json
+++ b/zagreus/assets/localization/en.json
@@ -182,6 +182,7 @@
     "radarr.Copy": "Copy",
     "radarr.CopyFiles": "Hardlink/Copy Files",
     "radarr.CopyFull": "Hardlink/Copy Files",
+    "radarr.CustomFormatScore": "Custom Format Score",
     "radarr.CutoffUnmet": "Cutoff Unmet",
     "radarr.DateAdded": "Date Added",
     "radarr.DigitalRelease": "Digital Release",

--- a/zagreus/lib/modules/radarr/core/types/sorting_releases.dart
+++ b/zagreus/lib/modules/radarr/core/types/sorting_releases.dart
@@ -177,18 +177,22 @@ class _Sorter {
 
   List<RadarrRelease> _customFormatScore(
       List<RadarrRelease> releases, bool ascending) {
+    // Note: For custom format score, ascending means high-to-low (reversed from normal)
+    // to match user expectations (highest scores are "best")
+    final sortDescending = ascending;
+
     releases.sort((a, b) {
       final aHasFormats = (a.customFormats?.isNotEmpty ?? false);
       final bHasFormats = (b.customFormats?.isNotEmpty ?? false);
 
       // Prioritize releases with formats over those without
-      if (!bHasFormats && aHasFormats) return ascending ? 1 : -1;
-      if (!aHasFormats && bHasFormats) return ascending ? -1 : 1;
+      if (!bHasFormats && aHasFormats) return sortDescending ? -1 : 1;
+      if (!aHasFormats && bHasFormats) return sortDescending ? 1 : -1;
 
       // Both have formats or both don't - sort by score
       final aScore = a.customFormatScore ?? 0;
       final bScore = b.customFormatScore ?? 0;
-      return ascending ? aScore.compareTo(bScore) : bScore.compareTo(aScore);
+      return sortDescending ? bScore.compareTo(aScore) : aScore.compareTo(bScore);
     });
 
     return releases;


### PR DESCRIPTION
- Reverse sort direction so highest scores show first by default (ascending=true now means descending for custom format scores)
- Add translation to assets/localization/en.json so button text displays correctly as "Custom Format Score" instead of "radarr.CustomFormatScore"

Now when users first click the sort option, they see the best releases (highest custom format scores) at the top, matching expected behavior.