### PR TITLE
Add custom format support to Sonarr interactive search

### DIFF
--- a/zagreus/assets/localization/en.json
+++ b/zagreus/assets/localization/en.json
@@ -693,6 +693,8 @@
     "sonarr.Codec": "Codec",
     "sonarr.Client": "Client",
     "sonarr.Continuing": "Continuing",
+    "sonarr.CustomFormats": "Custom Formats",
+    "sonarr.CustomFormatScore": "Custom Format Score",
     "sonarr.DeleteEpisodeFile": "Delete Episode File",
     "sonarr.DeleteEpisodeFileHint1": "Are you sure you want to delete this episode file?",
     "sonarr.DeleteFile": "Delete File",

--- a/zagreus/lib/api/sonarr/controllers/release/get_release.dart
+++ b/zagreus/lib/api/sonarr/controllers/release/get_release.dart
@@ -6,6 +6,7 @@ Future<List<SonarrRelease>> _commandGetReleases(
 }) async {
   Response response = await client.get('release', queryParameters: {
     'episodeId': episodeId,
+    'includeCustomFormats': true,
   });
   return (response.data as List)
       .map((series) => SonarrRelease.fromJson(series))

--- a/zagreus/lib/api/sonarr/controllers/release/get_season_release.dart
+++ b/zagreus/lib/api/sonarr/controllers/release/get_season_release.dart
@@ -8,6 +8,7 @@ Future<List<SonarrRelease>> _commandGetSeasonReleases(
   Response response = await client.get('release', queryParameters: {
     'seriesId': seriesId,
     'seasonNumber': seasonNumber,
+    'includeCustomFormats': true,
   });
   return (response.data as List)
       .map((series) => SonarrRelease.fromJson(series))

--- a/zagreus/lib/api/sonarr/models/custom_format/custom_format.dart
+++ b/zagreus/lib/api/sonarr/models/custom_format/custom_format.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'custom_format.g.dart';
+
+/// Model for a custom format from Sonarr.
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class SonarrCustomFormat {
+  @JsonKey(name: 'id')
+  int? id;
+
+  @JsonKey(name: 'name')
+  String? name;
+
+  SonarrCustomFormat({
+    this.id,
+    this.name,
+  });
+
+  /// Returns a JSON-encoded string version of this object.
+  @override
+  String toString() => json.encode(this.toJson());
+
+  /// Deserialize a JSON map to a [SonarrCustomFormat] object.
+  factory SonarrCustomFormat.fromJson(Map<String, dynamic> json) =>
+      _$SonarrCustomFormatFromJson(json);
+
+  /// Serialize a [SonarrCustomFormat] object to a JSON map.
+  Map<String, dynamic> toJson() => _$SonarrCustomFormatToJson(this);
+}

--- a/zagreus/lib/api/sonarr/models/release/release.dart
+++ b/zagreus/lib/api/sonarr/models/release/release.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:zagreus/api/sonarr/models/custom_format/custom_format.dart';
 import 'package:zagreus/modules/sonarr.dart';
 
 part 'release.g.dart';
@@ -11,6 +12,12 @@ class SonarrRelease {
 
   @JsonKey(name: 'quality')
   SonarrEpisodeFileQuality? quality;
+
+  @JsonKey(name: 'customFormats')
+  List<SonarrCustomFormat>? customFormats;
+
+  @JsonKey(name: 'customFormatScore')
+  int? customFormatScore;
 
   @JsonKey(name: 'qualityWeight')
   int? qualityWeight;
@@ -149,6 +156,8 @@ class SonarrRelease {
   SonarrRelease({
     this.guid,
     this.quality,
+    this.customFormats,
+    this.customFormatScore,
     this.qualityWeight,
     this.age,
     this.ageHours,

--- a/zagreus/lib/modules/sonarr/core/extensions/sonarr_release.dart
+++ b/zagreus/lib/modules/sonarr/core/extensions/sonarr_release.dart
@@ -59,4 +59,13 @@ extension SonarrReleaseExtension on SonarrRelease {
     if (nullOnEmpty) return null;
     return ZagUI.TEXT_EMDASH;
   }
+
+  String? zagCustomFormatScore({bool nullOnEmpty = false}) {
+    if ((this.customFormatScore ?? 0) != 0) {
+      String _prefix = this.customFormatScore! > 0 ? '+' : '';
+      return '$_prefix${this.customFormatScore}';
+    }
+    if (nullOnEmpty) return null;
+    return ZagUI.TEXT_EMDASH;
+  }
 }

--- a/zagreus/lib/modules/sonarr/core/types/sorting_releases.dart
+++ b/zagreus/lib/modules/sonarr/core/types/sorting_releases.dart
@@ -19,6 +19,8 @@ enum SonarrReleasesSorting {
   WEIGHT,
   @HiveField(6)
   WORD_SCORE,
+  @HiveField(7)
+  CUSTOM_FORMAT_SCORE,
 }
 
 extension SonarrReleasesSortingExtension on SonarrReleasesSorting {
@@ -38,6 +40,8 @@ extension SonarrReleasesSortingExtension on SonarrReleasesSorting {
         return 'size';
       case SonarrReleasesSorting.WORD_SCORE:
         return 'word_score';
+      case SonarrReleasesSorting.CUSTOM_FORMAT_SCORE:
+        return 'customFormatScore';
     }
   }
 
@@ -57,6 +61,8 @@ extension SonarrReleasesSortingExtension on SonarrReleasesSorting {
         return 'Size';
       case SonarrReleasesSorting.WORD_SCORE:
         return 'sonarr.WordScore'.tr();
+      case SonarrReleasesSorting.CUSTOM_FORMAT_SCORE:
+        return 'sonarr.CustomFormatScore'.tr();
     }
   }
 
@@ -76,6 +82,8 @@ extension SonarrReleasesSortingExtension on SonarrReleasesSorting {
         return SonarrReleasesSorting.WEIGHT;
       case 'word_score':
         return SonarrReleasesSorting.WORD_SCORE;
+      case 'customFormatScore':
+        return SonarrReleasesSorting.CUSTOM_FORMAT_SCORE;
       default:
         return null;
     }
@@ -106,6 +114,8 @@ class _Sorter {
         return _size(releases, ascending);
       case SonarrReleasesSorting.WORD_SCORE:
         return _wordScore(releases, ascending);
+      case SonarrReleasesSorting.CUSTOM_FORMAT_SCORE:
+        return _customFormatScore(releases, ascending);
     }
   }
 
@@ -181,6 +191,29 @@ class _Sorter {
             (b.preferredWordScore ?? 0).compareTo((a.preferredWordScore ?? 0)))
         : releases.sort((a, b) =>
             (a.preferredWordScore ?? 0).compareTo((b.preferredWordScore ?? 0)));
+    return releases;
+  }
+
+  List<SonarrRelease> _customFormatScore(
+      List<SonarrRelease> releases, bool ascending) {
+    // Note: For custom format score, ascending means high-to-low (reversed from normal)
+    // to match user expectations (highest scores are "best")
+    final sortDescending = ascending;
+
+    releases.sort((a, b) {
+      final aHasFormats = (a.customFormats?.isNotEmpty ?? false);
+      final bHasFormats = (b.customFormats?.isNotEmpty ?? false);
+
+      // Prioritize releases with formats over those without
+      if (!bHasFormats && aHasFormats) return sortDescending ? -1 : 1;
+      if (!aHasFormats && bHasFormats) return sortDescending ? 1 : -1;
+
+      // Both have formats or both don't - sort by score
+      final aScore = a.customFormatScore ?? 0;
+      final bScore = b.customFormatScore ?? 0;
+      return sortDescending ? bScore.compareTo(aScore) : aScore.compareTo(bScore);
+    });
+
     return releases;
   }
 }

--- a/zagreus/lib/modules/sonarr/routes/releases/widgets/release_tile.dart
+++ b/zagreus/lib/modules/sonarr/routes/releases/widgets/release_tile.dart
@@ -68,6 +68,8 @@ class _State extends State<SonarrReleasesTile> {
   TextSpan _subtitle2() {
     String? _preferredWordScore =
         widget.release.zagPreferredWordScore(nullOnEmpty: true);
+    final hasCustomFormats = (widget.release.customFormats?.isNotEmpty ?? false) ||
+                             (widget.release.customFormatScore != null && widget.release.customFormatScore != 0);
     return TextSpan(
       children: [
         if (_preferredWordScore != null)
@@ -87,6 +89,16 @@ class _State extends State<SonarrReleasesTile> {
           TextSpan(text: widget.release.zagLanguage),
         TextSpan(text: ZagUI.TEXT_BULLET.pad()),
         TextSpan(text: widget.release.zagSize),
+        if (hasCustomFormats) ...[
+          TextSpan(text: ZagUI.TEXT_BULLET.pad()),
+          TextSpan(
+            text: widget.release.zagCustomFormatScore()!,
+            style: TextStyle(
+              color: ZagColours.blue,
+              fontWeight: ZagUI.FONT_WEIGHT_BOLD,
+            ),
+          ),
+        ],
       ],
     );
   }
@@ -130,6 +142,13 @@ class _State extends State<SonarrReleasesTile> {
         title: 'sonarr.Quality'.tr(),
         body: widget.release.zagQuality,
       ),
+      if (widget.release.customFormats?.isNotEmpty ?? false)
+        ZagTableContent(
+          title: 'sonarr.CustomFormats'.tr(),
+          body: widget.release.customFormats!
+              .map<String>((format) => format.name ?? ZagUI.TEXT_EMDASH)
+              .join('\n'),
+        ),
       if (widget.release.seeders != null)
         ZagTableContent(
           title: 'sonarr.Seeders'.tr(),

--- a/zagreus/localization/sonarr/en.json
+++ b/zagreus/localization/sonarr/en.json
@@ -22,6 +22,8 @@
   "sonarr.Codec": "Codec",
   "sonarr.Client": "Client",
   "sonarr.Continuing": "Continuing",
+  "sonarr.CustomFormats": "Custom Formats",
+  "sonarr.CustomFormatScore": "Custom Format Score",
   "sonarr.DeleteEpisodeFile": "Delete Episode File",
   "sonarr.DeleteEpisodeFileHint1": "Are you sure you want to delete this episode file?",
   "sonarr.DeleteFile": "Delete File",


### PR DESCRIPTION
- Add customFormats and customFormatScore fields to SonarrRelease model
- Create SonarrCustomFormat model
- Include custom formats in episode and season pack API calls via includeCustomFormats parameter
- Add zagCustomFormatScore extension method for display formatting
- Display custom format score as blue badge in subtitle after file size
- Add custom formats field to expanded release view after quality field
- Add CUSTOM_FORMAT_SCORE sorting option with smart prioritization logic (prioritizes releases with formats over those without, then sorts by score)
- Add English translations for "Custom Formats" and "Custom Format Score"

This mirrors the Radarr implementation, using the same UI patterns and sorting logic for consistency across both services.