### PR TITLE
Set default server tab column order

### DIFF
--- a/zagreus/lib/database/tables/unraid.dart
+++ b/zagreus/lib/database/tables/unraid.dart
@@ -3,7 +3,7 @@ import 'package:zagreus/vendor.dart';
 
 enum UnraidDatabase<T> with ZagTableMixin<T> {
   NAVIGATION_INDEX<int>(0),
-  SECTION_ORDER<List>(const ['server_issues', 'overseerr_requests', 'disk_space', 'download_history']),
+  SECTION_ORDER<List>(const ['disk_space', 'download_history', 'server_issues']),
   OVERSEERR_REQUEST_FILTER<String>('pending');
 
   @override

--- a/zagreus/lib/modules/discover/widgets/server_sections_editor.dart
+++ b/zagreus/lib/modules/discover/widgets/server_sections_editor.dart
@@ -15,13 +15,19 @@ class ServerSectionsEditor extends StatefulWidget {
 }
 
 class ServerSectionsEditorState extends State<ServerSectionsEditor> {
-  static const List<String> _defaultSections = [
+  static const List<String> _allSections = [
     'server_issues',
     'overseerr_requests',
     'disk_space',
     'download_history',
     'lidarr_recent',
     'readarr_recent',
+  ];
+
+  static const List<String> _defaultSections = [
+    'disk_space',
+    'download_history',
+    'server_issues',
   ];
 
   static const Map<String, String> _sectionNames = {
@@ -224,7 +230,7 @@ class ServerSectionsEditorState extends State<ServerSectionsEditor> {
   }
 
   List<String> _availableSections() {
-    return _defaultSections
+    return _allSections
         .where((section) => !_sections.contains(section))
         .toList();
   }


### PR DESCRIPTION
Changes:
- Set default section order: disk space, download history, server issues
- Hide Lidarr albums and Readarr books sections by default
- Users can still add hidden sections via the editor
- Updated both database fallback and editor defaults