### PR TITLE
Add overseerr requests to default server tab sections

### DIFF
--- a/zagreus/lib/database/tables/unraid.dart
+++ b/zagreus/lib/database/tables/unraid.dart
@@ -3,7 +3,7 @@ import 'package:zagreus/vendor.dart';
 
 enum UnraidDatabase<T> with ZagTableMixin<T> {
   NAVIGATION_INDEX<int>(0),
-  SECTION_ORDER<List>(const ['disk_space', 'download_history', 'server_issues']),
+  SECTION_ORDER<List>(const ['disk_space', 'download_history', 'server_issues', 'overseerr_requests']),
   OVERSEERR_REQUEST_FILTER<String>('pending');
 
   @override

--- a/zagreus/lib/modules/discover/widgets/server_sections_editor.dart
+++ b/zagreus/lib/modules/discover/widgets/server_sections_editor.dart
@@ -28,6 +28,7 @@ class ServerSectionsEditorState extends State<ServerSectionsEditor> {
     'disk_space',
     'download_history',
     'server_issues',
+    'overseerr_requests',
   ];
 
   static const Map<String, String> _sectionNames = {


### PR DESCRIPTION
- Added overseerr_requests as the 4th default section
- Default order now: disk space, download history, server issues, overseerr requests
- Lidarr albums and Readarr books remain hidden by default