### PR TITLE
Add Tautulli Streams card to dashboard

### DIFF
--- a/zagreus/lib/database/tables/unraid.dart
+++ b/zagreus/lib/database/tables/unraid.dart
@@ -3,7 +3,7 @@ import 'package:zagreus/vendor.dart';
 
 enum UnraidDatabase<T> with ZagTableMixin<T> {
   NAVIGATION_INDEX<int>(0),
-  SECTION_ORDER<List>(const ['disk_space', 'download_history', 'server_issues', 'overseerr_requests']),
+  SECTION_ORDER<List>(const ['disk_space', 'download_history', 'server_issues', 'overseerr_requests', 'tautulli_streams']),
   OVERSEERR_REQUEST_FILTER<String>('pending');
 
   @override

--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -47,6 +47,11 @@ import 'package:zagreus/utils/zagreus_ultra.dart';
 import 'package:zagreus/services/deep_cuts_service.dart';
 import 'package:zagreus/modules/overseerr/core/extensions.dart';
 import 'package:zagreus/modules/overseerr/core/state.dart';
+import 'package:zagreus/modules/tautulli/core/state.dart';
+import 'package:zagreus/modules/discover/widgets/tautulli_stream_card.dart';
+import 'package:zagreus/api/tautulli/tautulli.dart';
+import 'package:zagreus/modules/tautulli.dart';
+import 'package:zagreus/router/routes/tautulli.dart';
 import 'package:zagreus/modules/sabnzbd/core/api/api.dart';
 import 'package:zagreus/modules/unraid/core/download_history_fetcher.dart';
 import 'package:zagreus/modules/unraid/routes/unraid/widgets/download_history_card.dart';
@@ -7412,6 +7417,17 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
   bool _isLoading = false;
   String? _error;
 
+  // Tautulli streams state
+  List<TautulliSession> _tautulliStreams = [];
+  bool _tautulliEnabled = false;
+  bool _tautulliLoading = false;
+  String? _tautulliError;
+  int? _tautulliStreamCount;
+  int? _tautulliDirectPlayCount;
+  int? _tautulliDirectStreamCount;
+  int? _tautulliTranscodeCount;
+  int? _tautulliBandwidth;
+
   @override
   void initState() {
     super.initState();
@@ -7424,6 +7440,7 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
       _loadDiskSpaces(),
       _loadServerIssues(),
       _loadOverseerrRequests(),
+      _loadTautulliStreams(),
       _loadDownloadHistory(),
       _loadLidarrRecentlyDownloaded(),
       _loadReadarrRecentlyDownloaded(),
@@ -7642,6 +7659,58 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
       _overseerrLoading ||
       _overseerrError != null ||
       _overseerrRequests.isNotEmpty;
+
+  Future<void> _loadTautulliStreams() async {
+    if (!mounted) return;
+
+    final tautulliState = context.read<TautulliState>();
+
+    if (!tautulliState.enabled) {
+      if (!mounted) return;
+      setState(() {
+        _tautulliEnabled = false;
+        _tautulliLoading = false;
+        _tautulliError = null;
+        _tautulliStreams = [];
+      });
+      return;
+    }
+
+    setState(() {
+      _tautulliEnabled = true;
+      _tautulliLoading = true;
+      _tautulliError = null;
+    });
+
+    try {
+      final activity = await tautulliState.api!.activity.getActivity();
+
+      if (!mounted) return;
+      setState(() {
+        _tautulliStreams = activity?.sessions ?? [];
+        _tautulliStreamCount = activity?.streamCount;
+        _tautulliDirectPlayCount = activity?.streamCountDirectPlay;
+        _tautulliDirectStreamCount = activity?.streamCountDirectStream;
+        _tautulliTranscodeCount = activity?.streamCountTranscode;
+        _tautulliBandwidth = activity?.totalBandwidth;
+        _tautulliLoading = false;
+      });
+    } catch (e) {
+      ZagLogger().warning('Failed to fetch Tautulli streams: $e');
+      if (!mounted) return;
+      setState(() {
+        _tautulliError = e.toString();
+        _tautulliLoading = false;
+        _tautulliStreams = [];
+      });
+    }
+  }
+
+  bool get _shouldShowTautulliStreamsSection =>
+      _tautulliEnabled ||
+      _tautulliLoading ||
+      _tautulliError != null ||
+      _tautulliStreams.isNotEmpty;
 
   Future<void> _loadDownloadHistory() async {
     if (!mounted) return;
@@ -7894,7 +7963,7 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
     final sectionOrder = UnraidDatabase.SECTION_ORDER.read() as List;
     final orderedSections = sectionOrder.isNotEmpty
         ? List<String>.from(sectionOrder)
-        : ['server_issues', 'overseerr_requests', 'disk_space', 'download_history', 'lidarr_recent', 'readarr_recent'];
+        : ['server_issues', 'overseerr_requests', 'tautulli_streams', 'disk_space', 'download_history', 'lidarr_recent', 'readarr_recent'];
 
     print('🎵 Ordered sections: $orderedSections');
     print('🎵 Lidarr enabled: ${ZagProfile.current.lidarrEnabled}');
@@ -7904,6 +7973,7 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
     final sectionWidgets = <String, List<Widget>>{
       'server_issues': _buildServerIssuesSection(),
       if (_shouldShowOverseerrSection) 'overseerr_requests': _buildOverseerrSection(),
+      if (_shouldShowTautulliStreamsSection) 'tautulli_streams': _buildTautulliStreamsSection(),
       'disk_space': _buildDiskSpaceSection(),
       if (ZagProfile.current.sabnzbdEnabled) 'download_history': _buildDownloadHistorySection(),
       if (ZagProfile.current.lidarrEnabled) 'lidarr_recent': _buildLidarrRecentSection(),
@@ -8169,6 +8239,152 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
           UnraidDatabase.OVERSEERR_REQUEST_FILTER.update(newFilter);
           _loadOverseerrRequests();
         },
+      ),
+    );
+  }
+
+  List<Widget> _buildTautulliStreamsSection() {
+    return [
+      Padding(
+        padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+        child: Row(
+          children: [
+            Text(
+              'Tautulli Streams',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: _tautulliEnabled
+                    ? ZagModule.TAUTULLI.color
+                    : Colors.grey,
+              ),
+            ),
+            const Spacer(),
+            if (_tautulliEnabled && _tautulliStreams.isNotEmpty)
+              _buildStreamsSummary(),
+          ],
+        ),
+      ),
+      if (_tautulliLoading)
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 24),
+          child: Center(
+            child: ZagLoader(),
+          ),
+        )
+      else if (!_tautulliEnabled)
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: ZagBlock(
+            title: 'Enable Tautulli',
+            body: const [
+              TextSpan(
+                text: 'Turn on Tautulli in Settings to see active streams here.',
+              ),
+            ],
+            trailing: const Icon(Icons.settings_rounded),
+            onTap: SettingsRoutes.CONFIGURATION_TAUTULLI.go,
+          ),
+        )
+      else if (_tautulliError != null)
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: ZagBlock(
+            title: 'Unable to load streams',
+            body: const [
+              TextSpan(
+                text: 'Tap to retry. We could not reach Tautulli.',
+              ),
+            ],
+            trailing: const Icon(Icons.refresh_rounded),
+            onTap: _loadTautulliStreams,
+          ),
+        )
+      else if (_tautulliStreams.isEmpty)
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: ZagBlock(
+            title: 'No Active Streams',
+            body: const [
+              TextSpan(text: 'Nobody is currently watching anything.'),
+            ],
+            trailing: const Icon(Icons.play_circle_outline_rounded),
+            onTap: () => ZagModule.TAUTULLI.launch(),
+          ),
+        )
+      else
+        ..._tautulliStreams
+            .map(
+              (stream) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: TautulliStreamCard(
+                  session: stream,
+                ),
+              ),
+            ),
+      const SizedBox(height: 24),
+    ];
+  }
+
+  Widget _buildStreamsSummary() {
+    final parts = <String>[];
+
+    if (_tautulliDirectPlayCount != null && _tautulliDirectPlayCount! > 0) {
+      parts.add('$_tautulliDirectPlayCount Direct Play');
+    }
+    if (_tautulliDirectStreamCount != null && _tautulliDirectStreamCount! > 0) {
+      parts.add('$_tautulliDirectStreamCount Direct Stream');
+    }
+    if (_tautulliTranscodeCount != null && _tautulliTranscodeCount! > 0) {
+      parts.add('$_tautulliTranscodeCount Transcode');
+    }
+
+    final summaryText = parts.isEmpty ? '' : parts.join(' • ');
+    final bandwidthText = _tautulliBandwidth != null
+        ? '${(_tautulliBandwidth! / 1000).toStringAsFixed(1)} Mbps'
+        : '';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: Theme.of(context).brightness == Brightness.dark
+            ? ZagColours.secondary
+            : ZagColours.secondaryLight,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: Theme.of(context).brightness == Brightness.dark
+              ? Colors.white10
+              : Colors.black12,
+          width: 1,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (summaryText.isNotEmpty)
+            Text(
+              summaryText,
+              style: TextStyle(
+                fontSize: 12,
+                color: ZagColours.accentColor(context),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          if (bandwidthText.isNotEmpty) ...[
+            const SizedBox(height: 2),
+            Text(
+              bandwidthText,
+              style: TextStyle(
+                fontSize: 14,
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? Colors.white
+                    : Colors.black,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/zagreus/lib/modules/discover/widgets/server_sections_editor.dart
+++ b/zagreus/lib/modules/discover/widgets/server_sections_editor.dart
@@ -18,6 +18,7 @@ class ServerSectionsEditorState extends State<ServerSectionsEditor> {
   static const List<String> _allSections = [
     'server_issues',
     'overseerr_requests',
+    'tautulli_streams',
     'disk_space',
     'download_history',
     'lidarr_recent',
@@ -29,11 +30,13 @@ class ServerSectionsEditorState extends State<ServerSectionsEditor> {
     'download_history',
     'server_issues',
     'overseerr_requests',
+    'tautulli_streams',
   ];
 
   static const Map<String, String> _sectionNames = {
     'server_issues': 'Server Issues',
     'overseerr_requests': 'Overseerr Requests',
+    'tautulli_streams': 'Tautulli Streams',
     'disk_space': 'Disk Space',
     'download_history': 'Download History',
     'lidarr_recent': 'Recently Downloaded Albums',
@@ -310,6 +313,8 @@ class ServerSectionsEditorState extends State<ServerSectionsEditor> {
         return Icons.warning_rounded;
       case 'overseerr_requests':
         return Icons.movie_filter_rounded;
+      case 'tautulli_streams':
+        return Icons.play_circle_outline_rounded;
       case 'disk_space':
         return Icons.storage_rounded;
       case 'download_history':

--- a/zagreus/lib/modules/discover/widgets/tautulli_stream_card.dart
+++ b/zagreus/lib/modules/discover/widgets/tautulli_stream_card.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:zagreus/core.dart';
+import 'package:zagreus/modules/tautulli.dart';
+
+class TautulliStreamCard extends StatelessWidget {
+  static final itemExtent = ZagBlock.calculateItemExtent(2, hasBottom: true);
+
+  final TautulliSession session;
+
+  const TautulliStreamCard({
+    Key? key,
+    required this.session,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ZagBlock(
+      key: ObjectKey(session),
+      title: session.zagTitle,
+      posterUrl: session.zagArtworkPath(context),
+      posterHeaders: context.read<TautulliState>().headers,
+      posterPlaceholderIcon: ZagIcons.VIDEO_CAM,
+      backgroundUrl: context.watch<TautulliState>().getImageURLFromPath(
+            session.art,
+            width: MediaQuery.of(context).size.width.truncate(),
+          ),
+      body: [
+        _subtitle1(),
+        _subtitle2(),
+      ],
+      bottom: _bottomWidget(),
+      bottomHeight: ZagLinearPercentIndicator.height,
+      trailing: ZagIconButton(icon: session.zagSessionStateIcon),
+      onTap: () => _enterDetails(context),
+    );
+  }
+
+  TextSpan _subtitle1() {
+    if (session.mediaType == TautulliMediaType.EPISODE) {
+      return TextSpan(
+        children: [
+          TextSpan(text: session.parentTitle),
+          TextSpan(text: ZagUI.TEXT_BULLET.pad()),
+          TextSpan(text: session.title ?? ZagUI.TEXT_EMDASH),
+        ],
+      );
+    }
+    if (session.mediaType == TautulliMediaType.MOVIE) {
+      return TextSpan(text: session.year?.toString() ?? '');
+    }
+    if (session.mediaType == TautulliMediaType.TRACK) {
+      return TextSpan(
+        children: [
+          TextSpan(text: session.parentTitle),
+          TextSpan(text: ZagUI.TEXT_EMDASH.pad()),
+          TextSpan(
+            style: TextStyle(
+              fontStyle: FontStyle.italic,
+            ),
+            text: session.title,
+          ),
+        ],
+      );
+    }
+    return TextSpan(text: session.title ?? ZagUI.TEXT_EMDASH);
+  }
+
+  TextSpan _subtitle2() {
+    return TextSpan(
+      children: [
+        TextSpan(text: session.zagFriendlyName),
+        TextSpan(text: ZagUI.TEXT_BULLET.pad()),
+        TextSpan(
+          text: session.formattedStream(),
+          style: TextStyle(
+            fontWeight: ZagUI.FONT_WEIGHT_BOLD,
+            color: ZagColours.currentAccent,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _bottomWidget() {
+    return SizedBox(
+      height: ZagLinearPercentIndicator.height,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          ZagLinearPercentIndicator(
+            percent: session.zagTranscodeProgress,
+            progressColor: ZagColours.currentAccent.withOpacity(
+              ZagUI.OPACITY_SPLASH,
+            ),
+            backgroundColor: Colors.transparent,
+          ),
+          ZagLinearPercentIndicator(
+            percent: session.zagProgressPercent,
+            progressColor: ZagColours.currentAccent,
+            backgroundColor: ZagColours.grey.withOpacity(
+              ZagUI.OPACITY_SPLASH,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _enterDetails(BuildContext context) async {
+    TautulliRoutes.ACTIVITY_DETAILS.go(params: {
+      'session': session.sessionKey.toString(),
+    });
+  }
+}


### PR DESCRIPTION
Implements a new Tautulli Streams section showing active Plex streams in the server tab:

Features:
- Displays real-time active streams from Tautulli
- Shows stream metadata (title, user, playback progress, bandwidth)
- Includes stream type breakdown (Direct Play, Direct Stream, Transcode)
- Auto-hides when no streams are active
- Positioned below Overseerr Requests by default

Changes:
- Created TautulliStreamCard widget for displaying individual streams
- Added tautulli_streams section to server tab configuration
- Integrated with existing Tautulli API for activity data
- Updated default server tab section order
- Added section to server sections editor with icon

The card reuses existing TautulliSession model and activity API endpoints, displaying streams similar to the Activity page but simplified for dashboard view.