### PR TITLE
Fix missing imports in TautulliStreamCard widget

### DIFF
--- a/zagreus/lib/modules/discover/widgets/tautulli_stream_card.dart
+++ b/zagreus/lib/modules/discover/widgets/tautulli_stream_card.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/core.dart';
+import 'package:zagreus/extensions/string/string.dart';
 import 'package:zagreus/modules/tautulli.dart';
+import 'package:zagreus/router/routes/tautulli.dart';
 
 class TautulliStreamCard extends StatelessWidget {
   static final itemExtent = ZagBlock.calculateItemExtent(2, hasBottom: true);


### PR DESCRIPTION
- Add string extension import for .pad() method
- Add TautulliRoutes import for navigation