### PR TITLE
Add custom format support to Lidarr interactive search

### DIFF
--- a/zagreus/lib/modules/lidarr/core/api/api.dart
+++ b/zagreus/lib/modules/lidarr/core/api/api.dart
@@ -711,6 +711,7 @@ class LidarrAPI {
         'release',
         queryParameters: {
           'albumId': albumID,
+          'includeCustomFormats': true,
         },
       );
       List<LidarrReleaseData> entries = [];
@@ -730,6 +731,10 @@ class LidarrAPI {
           rejections: entry['rejections'] ?? [],
           seeders: entry['seeders'] ?? 0,
           leechers: entry['leechers'] ?? 0,
+          customFormats: entry['customFormats'] != null
+              ? List<String>.from(entry['customFormats'])
+              : null,
+          customFormatScore: entry['customFormatScore'],
         ));
       }
       return entries;

--- a/zagreus/lib/modules/lidarr/core/api/data/release.dart
+++ b/zagreus/lib/modules/lidarr/core/api/data/release.dart
@@ -13,6 +13,8 @@ class LidarrReleaseData {
   int? leechers;
   double ageHours;
   List<dynamic> rejections;
+  List<String>? customFormats;
+  int? customFormatScore;
 
   LidarrReleaseData({
     required this.title,
@@ -29,9 +31,20 @@ class LidarrReleaseData {
     required this.rejections,
     this.seeders,
     this.leechers,
+    this.customFormats,
+    this.customFormatScore,
   });
 
   bool get isTorrent {
     return protocol == 'torrent';
+  }
+
+  String? zagCustomFormatScore({bool nullOnEmpty = false}) {
+    if ((customFormatScore ?? 0) != 0) {
+      String prefix = customFormatScore! > 0 ? '+' : '';
+      return '$prefix$customFormatScore';
+    }
+    if (nullOnEmpty) return null;
+    return '—';
   }
 }

--- a/zagreus/lib/modules/lidarr/core/sorting/releases.dart
+++ b/zagreus/lib/modules/lidarr/core/sorting/releases.dart
@@ -7,6 +7,7 @@ enum LidarrReleasesSorting {
   size,
   type,
   weight,
+  customFormatScore,
 }
 
 extension LidarrReleasesSortingExtension on LidarrReleasesSorting {
@@ -24,6 +25,8 @@ extension LidarrReleasesSortingExtension on LidarrReleasesSorting {
         return 'type';
       case LidarrReleasesSorting.size:
         return 'size';
+      case LidarrReleasesSorting.customFormatScore:
+        return 'customFormatScore';
     }
   }
 
@@ -41,6 +44,8 @@ extension LidarrReleasesSortingExtension on LidarrReleasesSorting {
         return 'Type';
       case LidarrReleasesSorting.size:
         return 'Size';
+      case LidarrReleasesSorting.customFormatScore:
+        return 'Custom Format Score';
     }
   }
 
@@ -67,6 +72,8 @@ class _Sorter {
         return _type(data, ascending);
       case LidarrReleasesSorting.size:
         return _size(data, ascending);
+      case LidarrReleasesSorting.customFormatScore:
+        return _customFormatScore(data, ascending);
     }
   }
 
@@ -120,6 +127,29 @@ class _Sorter {
     ascending
         ? _data.sort((a, b) => a.size.compareTo(b.size))
         : _data.sort((a, b) => b.size.compareTo(a.size));
+    return _data;
+  }
+
+  List<LidarrReleaseData> _customFormatScore(List data, bool ascending) {
+    List<LidarrReleaseData> _data = List.from(data, growable: false);
+    // Note: For custom format score, ascending means high-to-low (reversed from normal)
+    // to match user expectations (highest scores are "best")
+    final sortDescending = ascending;
+
+    _data.sort((a, b) {
+      final aHasFormats = (a.customFormats?.isNotEmpty ?? false);
+      final bHasFormats = (b.customFormats?.isNotEmpty ?? false);
+
+      // Prioritize releases with formats over those without
+      if (!bHasFormats && aHasFormats) return sortDescending ? -1 : 1;
+      if (!aHasFormats && bHasFormats) return sortDescending ? 1 : -1;
+
+      // Both have formats or both don't - sort by score
+      final aScore = a.customFormatScore ?? 0;
+      final bScore = b.customFormatScore ?? 0;
+      return sortDescending ? bScore.compareTo(aScore) : aScore.compareTo(bScore);
+    });
+
     return _data;
   }
 }

--- a/zagreus/lib/modules/lidarr/widgets/search_result_tile.dart
+++ b/zagreus/lib/modules/lidarr/widgets/search_result_tile.dart
@@ -62,11 +62,23 @@ class _State extends State<LidarrReleasesTile> {
   }
 
   TextSpan _subtitle2() {
+    final hasCustomFormats = (widget.release.customFormats?.isNotEmpty ?? false) ||
+                             (widget.release.customFormatScore != null && widget.release.customFormatScore != 0);
     return TextSpan(
       children: [
         TextSpan(text: widget.release.quality),
         TextSpan(text: ZagUI.TEXT_BULLET.pad()),
         TextSpan(text: widget.release.size.asBytes()),
+        if (hasCustomFormats) ...[
+          TextSpan(text: ZagUI.TEXT_BULLET.pad()),
+          TextSpan(
+            text: widget.release.zagCustomFormatScore()!,
+            style: TextStyle(
+              color: ZagColours.blue,
+              fontWeight: ZagUI.FONT_WEIGHT_BOLD,
+            ),
+          ),
+        ],
       ],
     );
   }
@@ -101,6 +113,11 @@ class _State extends State<LidarrReleasesTile> {
       ZagTableContent(title: 'indexer', body: widget.release.indexer),
       ZagTableContent(title: 'size', body: widget.release.size.asBytes()),
       ZagTableContent(title: 'quality', body: widget.release.quality),
+      if (widget.release.customFormats?.isNotEmpty ?? false)
+        ZagTableContent(
+          title: 'custom formats',
+          body: widget.release.customFormats!.join('\n'),
+        ),
       if (widget.release.protocol == 'torrent' &&
           widget.release.seeders != null)
         ZagTableContent(title: 'seeders', body: '${widget.release.seeders}'),


### PR DESCRIPTION
- Add customFormats (List<String>) and customFormatScore fields to LidarrReleaseData model
- Include custom formats in API call via includeCustomFormats parameter
- Parse customFormats as List<String> (Lidarr uses format names directly, not objects)
- Add zagCustomFormatScore() helper method for display formatting
- Display custom format score as blue badge in subtitle after file size
- Add "custom formats" field to expanded release view after quality field
- Add customFormatScore sorting option with smart prioritization logic (prioritizes releases with formats over those without, then sorts by score)

This completes custom format support across all three services (Radarr, Sonarr, Lidarr). Key difference: Lidarr uses List<String> for format names instead of List<CustomFormat> objects.