### PR TITLE
Add interactive Lidarr search button to album details

### DIFF
--- a/zagreus/lib/modules/lidarr/routes/details_album.dart
+++ b/zagreus/lib/modules/lidarr/routes/details_album.dart
@@ -56,9 +56,12 @@ class _State extends State<ArtistAlbumDetailsRoute>
       scrollControllers: [scrollController],
       actions: <Widget>[
         ZagIconButton(
+          icon: Icons.manage_search_rounded,
+          onPressed: () async => _manualSearch(),
+        ),
+        ZagIconButton(
           icon: Icons.search_rounded,
           onPressed: () async => _automaticSearch(),
-          onLongPress: () async => _manualSearch(),
         ),
       ],
     );


### PR DESCRIPTION
Adds a dedicated interactive search button to the album details app bar, allowing users to manually select releases. The button uses the manage_search_rounded icon and is positioned next to the automatic search button.