### PR TITLE
Fix custom format parsing in getReleases

### DIFF
--- a/zagreus/lib/modules/lidarr/core/api/api.dart
+++ b/zagreus/lib/modules/lidarr/core/api/api.dart
@@ -732,7 +732,10 @@ class LidarrAPI {
           seeders: entry['seeders'] ?? 0,
           leechers: entry['leechers'] ?? 0,
           customFormats: entry['customFormats'] != null
-              ? List<String>.from(entry['customFormats'])
+              ? (entry['customFormats'] as List)
+                  .map((cf) => cf is String ? cf : cf['name']?.toString() ?? '')
+                  .toList()
+                  .cast<String>()
               : null,
           customFormatScore: entry['customFormatScore'],
         ));


### PR DESCRIPTION
Custom formats are returned as objects with name/id fields, not strings. Updated parsing to extract the name field from each custom format object.