### PR TITLE
Remove separate module memory toggle - it's now part of Speed Cube

### DIFF
--- a/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:zagreus/core.dart';
-import 'package:zagreus/system/session_state.dart';
 import 'package:zagreus/utils/zagreus_pro.dart';
 
 class ConfigurationNavigationRoute extends StatefulWidget {
@@ -39,7 +38,6 @@ class _State extends State<ConfigurationNavigationRoute>
         _downloadsDrawer(),
         _legacyModulesTabToggle(),
         _speedCube(),
-        _moduleTabMemoryToggle(),
       ],
     );
   }
@@ -68,45 +66,13 @@ class _State extends State<ConfigurationNavigationRoute>
       builder: (context, _) => ZagBlock(
         title: 'Speed Cube',
         body: const [
-          TextSpan(text: 'Show the floating module switcher button.'),
+          TextSpan(text: 'Show the floating module switcher button with long-press bounce-back.'),
         ],
         trailing: ZagSwitch(
           value: db.read(),
           onChanged: db.update,
         ),
       ),
-    );
-  }
-
-  Widget _moduleTabMemoryToggle() {
-    const cubeDb = ZagreusDatabase.SPEED_CUBE_ENABLED;
-    const memoryDb = ZagreusDatabase.MODULE_TAB_MEMORY_ENABLED;
-
-    return cubeDb.listenableBuilder(
-      builder: (context, _) {
-        final cubeEnabled = cubeDb.read();
-        return memoryDb.listenableBuilder(
-          builder: (context, _) => ZagBlock(
-            title: 'Remember Module Page',
-            body: const [
-              TextSpan(
-                text: 'Jump back to the last page you viewed.',
-              ),
-            ],
-            trailing: ZagSwitch(
-              value: cubeEnabled ? memoryDb.read() : false,
-              onChanged: cubeEnabled
-                  ? (value) {
-                      memoryDb.update(value);
-                      if (!value) {
-                        ZagSessionState.instance.clearAllModuleTabPositions();
-                      }
-                    }
-                  : null,
-            ),
-          ),
-        );
-      },
     );
   }
 

--- a/zagreus/lib/router/router.dart
+++ b/zagreus/lib/router/router.dart
@@ -110,9 +110,9 @@ class _RouteLocationTracker {
   }
 
   void _handleLocationChange() {
-    // Skip if module tab memory is disabled
-    if (!ZagreusDatabase.MODULE_TAB_MEMORY_ENABLED.read()) {
-      print('🔍 RouteTracker: Memory disabled, skipping');
+    // Skip if Speed Cube is disabled (route memory is part of the cube feature)
+    if (!ZagreusDatabase.SPEED_CUBE_ENABLED.read()) {
+      print('🔍 RouteTracker: Speed Cube disabled, skipping');
       return;
     }
 

--- a/zagreus/lib/system/session_state.dart
+++ b/zagreus/lib/system/session_state.dart
@@ -12,7 +12,7 @@ class ZagSessionState {
   // Module last visited routes (module key -> full route path)
   final Map<String, String> _moduleLastRoutes = {};
 
-  bool get tabMemoryEnabled => ZagreusDatabase.MODULE_TAB_MEMORY_ENABLED.read();
+  bool get tabMemoryEnabled => ZagreusDatabase.SPEED_CUBE_ENABLED.read();
 
   /// Get the saved tab position for a module, or null if not set
   int? getModuleTabPosition(String moduleKey) {


### PR DESCRIPTION
Route memory is no longer a separate setting. It's now an integrated part of the Speed Cube experience:

- When Speed Cube is enabled: Long-press bounce-back works automatically
- When Speed Cube is disabled: No route tracking (efficient)

Changes:
1. Removed 'Remember Module Page' toggle from settings UI
2. Updated Speed Cube description to mention long-press bounce-back
3. Changed all MODULE_TAB_MEMORY_ENABLED checks to SPEED_CUBE_ENABLED
4. Route tracking now only active when cube is enabled

This makes the feature feel natural and integrated - no separate toggle needed. The bounce-back is just part of how the cube works.