### PR TITLE
Fix Settings gear icon always going to home page

### DIFF
--- a/zagreus/lib/widgets/ui/drawer/drawer_header.dart
+++ b/zagreus/lib/widgets/ui/drawer/drawer_header.dart
@@ -34,7 +34,7 @@ class ZagDrawerHeader extends StatelessWidget {
                 final unlocked =
                     await SettingsLockService.instance.ensureUnlocked(context);
                 if (unlocked) {
-                  ZagModule.SETTINGS.launch();
+                  ZagModule.SETTINGS.launch(restore: false);
                 }
               },
               onLongPress: () {


### PR DESCRIPTION
The gear icon in the drawer header was calling SETTINGS.launch() without restore: false, causing it to restore the last visited settings page instead of always going to home.

This is consistent with all other navigation (drawer, modules page, FAB) which now use restore: false to always go to home. Only the Speed Cube long-press uses restore: true for bounce-back.