### PR TITLE
Use compact progress bar in disk space section

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -8098,7 +8098,7 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
               for (int i = 0; i < _diskSpaces.length; i++) ...[
                 _buildDiskSpaceItem(_diskSpaces[i]),
                 if (i < _diskSpaces.length - 1)
-                  const SizedBox(height: 8),
+                  const SizedBox(height: 16),
               ],
             ],
           ),
@@ -8143,6 +8143,7 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
           ),
         ),
         ZagLinearPercentIndicator(
+          compact: true,
           percent: diskSpace.zagPercentage / 100,
           progressColor: diskSpace.zagColor,
         ),


### PR DESCRIPTION
- Enable compact mode on ZagLinearPercentIndicator (4px tall instead of 12px)
- Increase spacing between items from 8px to 16px
- Matches SABnzbd queue tile style for thinner, cleaner progress bars
- Eliminates massive internal gap caused by default progress bar height