### PR TITLE
Fix gap above progress bar in disk space items

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -8142,10 +8142,13 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
                 : Colors.black54,
           ),
         ),
-        ZagLinearPercentIndicator(
-          compact: true,
-          percent: diskSpace.zagPercentage / 100,
-          progressColor: diskSpace.zagColor,
+        SizedBox(
+          height: 4,
+          child: ZagLinearPercentIndicator(
+            compact: true,
+            percent: diskSpace.zagPercentage / 100,
+            progressColor: diskSpace.zagColor,
+          ),
         ),
       ],
     );


### PR DESCRIPTION
Wrap compact progress bar in SizedBox with height: 4 to clip the built-in padding. The compact progress bar has compactHeight (10px) which includes 6px of padding above the 4px bar. By constraining to 4px height, we eliminate the unwanted gap between disk info and progress bar.