### PR TITLE
Add subtle 2px spacing between disk space item elements

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -8139,6 +8139,7 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
             ],
           ),
         ),
+        const SizedBox(height: 2),
         SizedBox(
           height: 14,
           child: Text(
@@ -8152,6 +8153,7 @@ class _ServerPageState extends State<_ServerPage> with AutomaticKeepAliveClientM
             ),
           ),
         ),
+        const SizedBox(height: 2),
         SizedBox(
           height: 4,
           child: ZagLinearPercentIndicator(


### PR DESCRIPTION
Adds tiny breathing room between title, size info, and progress bar for better visual separation while maintaining compact layout