### PR TITLE
Reset background image opacity to 20% for all users

### DIFF
--- a/zagreus/lib/database/database.dart
+++ b/zagreus/lib/database/database.dart
@@ -24,6 +24,25 @@ class ZagDatabase {
   Future<void> open() async {
     await ZagBox.open();
     if (ZagBox.profiles.isEmpty) await bootstrap();
+    await _runMigrations();
+  }
+
+  /// Run database migrations for version updates
+  Future<void> _runMigrations() async {
+    await _migrateOpacityTo20();
+  }
+
+  /// Migration: Reset background image opacity from 25% to 20%
+  /// This migration fixes users who were stuck at 25% opacity after
+  /// toggling the "Use Original Colors" setting.
+  Future<void> _migrateOpacityTo20() async {
+    const opacityKey = ZagreusDatabase.THEME_IMAGE_BACKGROUND_OPACITY;
+    final currentOpacity = opacityKey.read();
+
+    // If user has 25% opacity, reset to 20%
+    if (currentOpacity == 25) {
+      opacityKey.update(20);
+    }
   }
 
   Future<void> nuke() async {

--- a/zagreus/lib/modules/settings/routes/configuration_appearance/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_appearance/route.dart
@@ -131,8 +131,6 @@ class _State extends State<ConfigurationAppearanceRoute>
           value: db.read(),
           onChanged: (value) {
             db.update(value);
-            ZagreusDatabase.THEME_IMAGE_BACKGROUND_OPACITY
-                .update(value ? 20 : 25);
             ZagTheme().initialize();
             ZagState.reset(context);
             showZagSnackBar(


### PR DESCRIPTION
- Remove automatic opacity change when toggling "Use Original Colors"
- Add database migration that resets users stuck at 25% opacity to 20%
- Migration runs automatically on app start for all affected users