### PR TITLE
Add option to hide calendar tab

### DIFF
--- a/zagreus/lib/database/tables/zagreus.dart
+++ b/zagreus/lib/database/tables/zagreus.dart
@@ -118,6 +118,7 @@ enum ZagreusDatabase<T> with ZagTableMixin<T> {
   DISCOVER_TRENDING_TIME_WINDOW<String>('day'),
   DISCOVER_DEFAULT_TAB<String>('modules'),
   SHOW_LEGACY_MODULES_TAB<bool>(true),
+  SHOW_CALENDAR_TAB<bool>(true),
   SHOW_AGENT_TAB<bool>(true);
 
   @override

--- a/zagreus/lib/modules/dashboard/core/dialogs.dart
+++ b/zagreus/lib/modules/dashboard/core/dialogs.dart
@@ -16,14 +16,17 @@ class DashboardDialogs {
       Navigator.of(context, rootNavigator: true).pop();
     }
 
+    final visibleTitles = HomeNavigationBar.getVisibleTitles();
+    final visibleIcons = HomeNavigationBar.getVisibleIcons();
+
     await ZagDialog.dialog(
       context: context,
       title: 'zagreus.Page'.tr(),
       content: List.generate(
-        HomeNavigationBar.titles.length,
+        visibleTitles.length,
         (index) => ZagDialog.tile(
-          text: HomeNavigationBar.titles[index],
-          icon: HomeNavigationBar.icons[index],
+          text: visibleTitles[index],
+          icon: visibleIcons[index],
           iconColor: ZagColours().byListIndex(index),
           onTap: () => _setValues(true, index),
         ),

--- a/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
@@ -43,6 +43,13 @@ class _State extends State<DashboardRoute> {
 
     print('🏠 Dashboard initState called');
     int page = DashboardDatabase.NAVIGATION_INDEX.read();
+
+    // Ensure the initial page is valid for the visible tabs
+    final visiblePageCount = _getVisiblePageCount();
+    if (page >= visiblePageCount) {
+      page = 0;
+    }
+
     _pageController = ZagPageController(initialPage: page);
 
     // Add listener to rebuild app bar when page changes
@@ -64,6 +71,36 @@ class _State extends State<DashboardRoute> {
         _updateWidget();
       });
     }
+  }
+
+  int _getVisiblePageCount() {
+    int count = 0;
+    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) count++;
+    if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) count++;
+    return count;
+  }
+
+  List<Widget> _getVisiblePages() {
+    final List<Widget> pages = [];
+    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+      pages.add(ModulesPage(key: ValueKey(ZagreusDatabase.ENABLED_PROFILE.read())));
+    }
+    if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
+      pages.add(CalendarPage(key: ValueKey(ZagreusDatabase.ENABLED_PROFILE.read())));
+    }
+    return pages;
+  }
+
+  int? _getVisiblePageIndex(int absoluteIndex) {
+    // Maps absolute page indices (0 = modules, 1 = calendar) to visible page indices
+    if (absoluteIndex == 0 && ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+      return 0; // Modules is always first if visible
+    }
+    if (absoluteIndex == 1 && ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
+      // Calendar is second if modules is visible, first otherwise
+      return ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read() ? 1 : 0;
+    }
+    return null; // Page is not visible
   }
 
   @override
@@ -157,7 +194,7 @@ class _State extends State<DashboardRoute> {
     return ZagAppBar(
       title: 'Zagreus',
       useDrawer: true,
-      scrollControllers: HomeNavigationBar.scrollControllers,
+      scrollControllers: HomeNavigationBar.getVisibleScrollControllers(),
       pageController: _pageController,
       actions: [
         Builder(
@@ -166,7 +203,11 @@ class _State extends State<DashboardRoute> {
             if (controller == null) return const SizedBox();
             final currentPage = controller.hasClients ? controller.page?.round() ?? 0 : 0;
 
-            if (currentPage == 0) {
+            // Check which page we're on based on visible tabs
+            final modulesIndex = _getVisiblePageIndex(0); // 0 = modules
+            final calendarIndex = _getVisiblePageIndex(1); // 1 = calendar
+
+            if (modulesIndex != null && currentPage == modulesIndex) {
               // Modules tab - show tier-based icons
               final isMegaOrUltra = ZagreusMega.isEnabled || ZagreusUltra.isEnabled;
               final isPro = ZagreusPro.isEnabled;
@@ -200,8 +241,13 @@ class _State extends State<DashboardRoute> {
               }
             }
 
-            // Calendar tab (page 1) - show view switcher for all users
-            return SwitchViewAction(pageController: _pageController);
+            if (calendarIndex != null && currentPage == calendarIndex) {
+              // Calendar tab - show view switcher for all users
+              return SwitchViewAction(pageController: _pageController);
+            }
+
+            // Default: show nothing
+            return const SizedBox();
           },
         ),
       ],
@@ -210,12 +256,21 @@ class _State extends State<DashboardRoute> {
 
   Widget _body() {
     final mainContent = ZagreusDatabase.ENABLED_PROFILE.listenableBuilder(
-      builder: (context, _) => ZagPageView(
-        controller: _pageController,
-        children: [
-          ModulesPage(key: ValueKey(ZagreusDatabase.ENABLED_PROFILE.read())),
-          CalendarPage(key: ValueKey(ZagreusDatabase.ENABLED_PROFILE.read())),
-        ],
+      builder: (context, _) => ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.listenableBuilder(
+        builder: (context, _) => ZagreusDatabase.SHOW_CALENDAR_TAB.listenableBuilder(
+          builder: (context, _) {
+            final visiblePages = _getVisiblePages();
+            if (visiblePages.isEmpty) {
+              return const Center(
+                child: Text('No tabs enabled. Please enable at least one tab in Settings > Navigation.'),
+              );
+            }
+            return ZagPageView(
+              controller: _pageController,
+              children: visiblePages,
+            );
+          },
+        ),
       ),
     );
 

--- a/zagreus/lib/modules/dashboard/routes/dashboard/widgets/navigation_bar.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/widgets/navigation_bar.dart
@@ -1,20 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/core.dart';
+import 'package:zagreus/database/tables/zagreus.dart';
 
 class HomeNavigationBar extends StatelessWidget {
   final PageController? pageController;
 
   static List<ScrollController> scrollControllers = List.generate(
-    icons.length,
+    2, // Max possible tabs
     (_) => ScrollController(),
   );
 
-  static final List<String> titles = [
+  static final List<String> _allTitles = [
     'dashboard.Modules'.tr(),
     'dashboard.Calendar'.tr(),
   ];
 
-  static const List<IconData> icons = [
+  static const List<IconData> _allIcons = [
     Icons.workspaces_rounded,
     Icons.calendar_today_rounded,
   ];
@@ -24,13 +25,60 @@ class HomeNavigationBar extends StatelessWidget {
     required this.pageController,
   }) : super(key: key);
 
+  static List<String> getVisibleTitles() {
+    final List<String> visibleTitles = [];
+    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+      visibleTitles.add(_allTitles[0]);
+    }
+    if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
+      visibleTitles.add(_allTitles[1]);
+    }
+    return visibleTitles;
+  }
+
+  static List<IconData> getVisibleIcons() {
+    final List<IconData> visibleIcons = [];
+    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+      visibleIcons.add(_allIcons[0]);
+    }
+    if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
+      visibleIcons.add(_allIcons[1]);
+    }
+    return visibleIcons;
+  }
+
+  static List<ScrollController> getVisibleScrollControllers() {
+    final List<ScrollController> visibleControllers = [];
+    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+      visibleControllers.add(scrollControllers[0]);
+    }
+    if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
+      visibleControllers.add(scrollControllers[1]);
+    }
+    return visibleControllers;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return ZagBottomNavigationBar(
-      pageController: pageController,
-      scrollControllers: scrollControllers,
-      icons: icons,
-      titles: titles,
+    return ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.listenableBuilder(
+      builder: (context, _) => ZagreusDatabase.SHOW_CALENDAR_TAB.listenableBuilder(
+        builder: (context, _) {
+          final visibleTitles = getVisibleTitles();
+          final visibleIcons = getVisibleIcons();
+          final visibleScrollControllers = getVisibleScrollControllers();
+
+          if (visibleTitles.isEmpty) {
+            return const SizedBox.shrink();
+          }
+
+          return ZagBottomNavigationBar(
+            pageController: pageController,
+            scrollControllers: visibleScrollControllers,
+            icons: visibleIcons,
+            titles: visibleTitles,
+          );
+        },
+      ),
     );
   }
 }

--- a/zagreus/lib/modules/settings/routes/configuration_dashboard/pages/default_pages.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_dashboard/pages/default_pages.dart
@@ -52,14 +52,36 @@ class _State extends State<ConfigurationDashboardDefaultPagesRoute>
   Widget _dashboardDefaultPageTile() {
     const _db = DashboardDatabase.NAVIGATION_INDEX;
     return _db.listenableBuilder(
-      builder: (context, _) => ZagBlock(
-        title: 'zagreus.Home'.tr(),
-        body: [TextSpan(text: HomeNavigationBar.titles[_db.read()])],
-        trailing: ZagIconButton(icon: HomeNavigationBar.icons[_db.read()]),
-        onTap: () async {
-          final values = await DashboardDialogs().defaultPage(context);
-          if (values.item1) _db.update(values.item2);
-        },
+      builder: (context, _) => ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.listenableBuilder(
+        builder: (context, _) => ZagreusDatabase.SHOW_CALENDAR_TAB.listenableBuilder(
+          builder: (context, _) {
+            final visibleTitles = HomeNavigationBar.getVisibleTitles();
+            final visibleIcons = HomeNavigationBar.getVisibleIcons();
+
+            if (visibleTitles.isEmpty) {
+              return const SizedBox.shrink();
+            }
+
+            // Ensure the index is within bounds
+            int index = _db.read();
+            if (index >= visibleTitles.length) {
+              index = 0;
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                _db.update(0);
+              });
+            }
+
+            return ZagBlock(
+              title: 'zagreus.Home'.tr(),
+              body: [TextSpan(text: visibleTitles[index])],
+              trailing: ZagIconButton(icon: visibleIcons[index]),
+              onTap: () async {
+                final values = await DashboardDialogs().defaultPage(context);
+                if (values.item1) _db.update(values.item2);
+              },
+            );
+          },
+        ),
       ),
     );
   }

--- a/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
@@ -37,6 +37,7 @@ class _State extends State<ConfigurationNavigationRoute>
         _horizontalSwipeToggle(),
         _downloadsDrawer(),
         _legacyModulesTabToggle(),
+        _calendarTabToggle(),
         _speedCube(),
       ],
     );
@@ -124,6 +125,25 @@ class _State extends State<ConfigurationNavigationRoute>
               ZagreusDatabase.DISCOVER_DEFAULT_TAB.update('modules');
             }
           },
+        ),
+      ),
+    );
+  }
+
+  Widget _calendarTabToggle() {
+    if (!ZagreusPro.isEnabled) return const SizedBox.shrink();
+    const db = ZagreusDatabase.SHOW_CALENDAR_TAB;
+    return db.listenableBuilder(
+      builder: (context, _) => ZagBlock(
+        title: 'Hide Calendar Tab',
+        body: const [
+          TextSpan(
+            text: 'Hides Calendar tab in Dashboard',
+          ),
+        ],
+        trailing: ZagSwitch(
+          value: !db.read(),
+          onChanged: (value) => db.update(!value),
         ),
       ),
     );


### PR DESCRIPTION
This change adds a new Pro-only setting to hide the Calendar tab, similar to the existing option to hide the Modules tab. The option is located in Settings > Navigation, right next to the Modules tab option.

Changes:
- Added SHOW_CALENDAR_TAB database field (defaults to true)
- Added "Hide Calendar Tab" toggle in Navigation settings (Pro-only)
- Updated navigation bar to dynamically show/hide tabs based on settings
- Updated dashboard route to handle dynamic page visibility
- Updated default page dialogs to work with visible tabs only
- Fixed page indexing to handle dynamic tab visibility

The implementation ensures that:
- At least one tab must remain visible
- Page indices are properly mapped when tabs are hidden
- Default page selection only shows visible tabs
- App bar actions correspond to the correct visible page