### PR TITLE
Add optional Local endpoints to modules

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/pages/modules.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/pages/modules.dart
@@ -9,6 +9,7 @@ import 'package:zagreus/api/wake_on_lan/wake_on_lan.dart';
 import 'package:zagreus/modules/dashboard/routes/dashboard/widgets/navigation_bar.dart';
 import 'package:zagreus/utils/zagreus_pro.dart';
 import 'package:zagreus/services/settings_lock_service.dart';
+import 'package:zagreus/system/network/local_switching_service.dart';
 
 class ModulesPage extends StatefulWidget {
   final ScrollController? controller;
@@ -39,12 +40,19 @@ class _State extends State<ModulesPage> with AutomaticKeepAliveClientMixin {
         onTap: () => ZagModule.SETTINGS.launch(restore: false),
       );
     }
-    return ZagListView(
-      controller: widget.controller ?? HomeNavigationBar.scrollControllers[0],
-      itemExtent: ZagBlock.calculateItemExtent(1),
-      children: ZagreusDatabase.DRAWER_AUTOMATIC_MANAGE.read()
-          ? _buildAlphabeticalList()
-          : _buildManuallyOrderedList(),
+
+    // Listen to SSID changes to update "• Local" indicators
+    return ValueListenableBuilder<String?>(
+      valueListenable: ZagLocalConnectionService().currentSsid,
+      builder: (context, ssid, child) {
+        return ZagListView(
+          controller: widget.controller ?? HomeNavigationBar.scrollControllers[0],
+          itemExtent: ZagBlock.calculateItemExtent(1),
+          children: ZagreusDatabase.DRAWER_AUTOMATIC_MANAGE.read()
+              ? _buildAlphabeticalList()
+              : _buildManuallyOrderedList(),
+        );
+      },
     );
   }
 
@@ -120,9 +128,15 @@ class _State extends State<ModulesPage> with AutomaticKeepAliveClientMixin {
       };
     }
 
+    // Build description with "• Local" suffix if module is using local endpoint
+    final isUsingLocal = ZagLocalConnectionService().isModuleUsingLocal(module);
+    final description = isUsingLocal
+        ? '${module.description} • Local'
+        : module.description;
+
     return ZagBlock(
       title: module.title,
-      body: [TextSpan(text: module.description)],
+      body: [TextSpan(text: description)],
       trailing: ZagIconButton(icon: module.icon, color: module.color),
       onTap: onTap,
     );

--- a/zagreus/lib/system/network/local_switching_service.dart
+++ b/zagreus/lib/system/network/local_switching_service.dart
@@ -146,6 +146,11 @@ class ZagLocalConnectionService {
     return trimmed.isEmpty ? null : trimmed;
   }
 
+  /// Returns true if the given module is currently using its local endpoint
+  bool isModuleUsingLocal(ZagModule module) {
+    return _moduleLocalState[module] ?? false;
+  }
+
   void _applySsidUpdate(
     String? ssid, {
     required String source,
@@ -249,6 +254,12 @@ class ZagLocalConnectionService {
         enabled: profile.unraidEnabled,
         localHost: profile.unraidLocalHost,
         ssids: profile.unraidLocalSsids,
+      ),
+      _LocalSwitchConfig(
+        module: ZagModule.READARR,
+        enabled: profile.readarrEnabled,
+        localHost: profile.readarrLocalHost,
+        ssids: profile.readarrLocalSsids,
       ),
     ];
   }


### PR DESCRIPTION
- Add isModuleUsingLocal() method to ZagLocalConnectionService to query module state
- Update ModulesPage to append '• Local' suffix to module descriptions when local endpoint is active
- Make dashboard reactive to SSID changes using ValueListenableBuilder
- Add Readarr to local switching configs (was missing from _collectConfigs)

This provides visual feedback on the dashboard showing which modules are currently using their local endpoints based on SSID matching.