### PR TITLE
Add catalogue filter option to scrolling runner

### DIFF
--- a/zagreus/lib/database/tables/zagreus.dart
+++ b/zagreus/lib/database/tables/zagreus.dart
@@ -116,6 +116,7 @@ enum ZagreusDatabase<T> with ZagTableMixin<T> {
   DISCOVER_SHOW_TITLES<bool>(true),
   DISCOVER_MONOCHROME_RATINGS<bool>(false),
   DISCOVER_TRENDING_TIME_WINDOW<String>('day'),
+  DISCOVER_FILTER_HERO_BY_TAB<bool>(true),
   DISCOVER_DEFAULT_TAB<String>('modules'),
   SHOW_LEGACY_MODULES_TAB<bool>(true),
   SHOW_CALENDAR_TAB<bool>(true),

--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -178,8 +178,13 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   Iterable<PageController> get _heroPageControllers =>
       [_moviesHeroPageController, _tvHeroPageController];
   int _currentHeroIndex = 0;
+  int _currentMovieHeroIndex = 0;
+  int _currentTVHeroIndex = 0;
   String _trendingTimeWindow = 'day'; // 'day' or 'week'
+  bool _filterHeroByTab = true;
   List<Map<String, dynamic>> _trendingItems = [];
+  List<Map<String, dynamic>> _trendingMovies = [];
+  List<Map<String, dynamic>> _trendingTVShows = [];
   Timer? _autoScrollTimer;
   final Set<String> _precachedHeroBackdrops = {};
   final Map<String, ScrollController> _sectionScrollControllers = {};
@@ -349,15 +354,36 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   void _startAutoScroll() {
     _autoScrollTimer?.cancel();
     _autoScrollTimer = Timer.periodic(const Duration(seconds: 5), (timer) {
-      if (_trendingItems.isEmpty) return;
-      final nextIndex = (_currentHeroIndex + 1) % _trendingItems.length;
-      _withHeroControllers((controller) {
-        controller.animateToPage(
-          nextIndex,
-          duration: const Duration(milliseconds: 500),
-          curve: Curves.easeInOut,
-        );
-      });
+      if (_filterHeroByTab) {
+        // Handle separate auto-scroll for movies and TV
+        if (_trendingMovies.isNotEmpty && _moviesHeroPageController.hasClients) {
+          final nextIndex = (_currentMovieHeroIndex + 1) % _trendingMovies.length;
+          _moviesHeroPageController.animateToPage(
+            nextIndex,
+            duration: const Duration(milliseconds: 500),
+            curve: Curves.easeInOut,
+          );
+        }
+        if (_trendingTVShows.isNotEmpty && _tvHeroPageController.hasClients) {
+          final nextIndex = (_currentTVHeroIndex + 1) % _trendingTVShows.length;
+          _tvHeroPageController.animateToPage(
+            nextIndex,
+            duration: const Duration(milliseconds: 500),
+            curve: Curves.easeInOut,
+          );
+        }
+      } else {
+        // Unified auto-scroll (original behavior)
+        if (_trendingItems.isEmpty) return;
+        final nextIndex = (_currentHeroIndex + 1) % _trendingItems.length;
+        _withHeroControllers((controller) {
+          controller.animateToPage(
+            nextIndex,
+            duration: const Duration(milliseconds: 500),
+            curve: Curves.easeInOut,
+          );
+        });
+      }
     });
   }
 
@@ -377,6 +403,11 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     } else {
       _trendingTimeWindow = 'day';
     }
+
+    final savedFilter = ZagreusDatabase.DISCOVER_FILTER_HERO_BY_TAB.read();
+    if (savedFilter != null) {
+      _filterHeroByTab = savedFilter;
+    }
   }
 
   void _loadMockTrendingData() {
@@ -385,31 +416,35 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
 
   Future<void> _loadTrendingData() async {
     try {
-      final items = await TMDBApi.getTrending(
-        mediaType: 'all', // Can be 'movie', 'tv', or 'all'
-        timeWindow: _trendingTimeWindow,
-      );
+      if (_filterHeroByTab) {
+        // Load separate lists for movies and TV shows
+        final movieItems = await TMDBApi.getTrending(
+          mediaType: 'movie',
+          timeWindow: _trendingTimeWindow,
+        );
 
-      // Check against Radarr library if available
-      if (mounted) {
-        final radarrState = context.read<RadarrState>();
-        if (radarrState.enabled && radarrState.movies != null) {
-          final movies = await radarrState.movies!;
-          for (final item in items) {
-            if (item['mediaType'] == 'movie') {
+        final tvItems = await TMDBApi.getTrending(
+          mediaType: 'tv',
+          timeWindow: _trendingTimeWindow,
+        );
+
+        // Check against Radarr library if available
+        if (mounted) {
+          final radarrState = context.read<RadarrState>();
+          if (radarrState.enabled && radarrState.movies != null) {
+            final movies = await radarrState.movies!;
+            for (final item in movieItems) {
               final tmdbId = item['tmdbId'] as int;
               item['inLibrary'] = movies.any((m) => m.tmdbId == tmdbId);
             }
           }
-        }
 
-        // Check against Sonarr library if available
-        final sonarrState = context.read<SonarrState>();
-        if (sonarrState.enabled && sonarrState.api != null) {
-          try {
-            final sonarrSeries = await sonarrState.api!.series.getAll();
-            for (final item in items) {
-              if (item['mediaType'] == 'tv') {
+          // Check against Sonarr library if available
+          final sonarrState = context.read<SonarrState>();
+          if (sonarrState.enabled && sonarrState.api != null) {
+            try {
+              final sonarrSeries = await sonarrState.api!.series.getAll();
+              for (final item in tvItems) {
                 final title = item['title'] as String;
                 // Check if this show is in Sonarr library by title match
                 final inLibrary = sonarrSeries.any((series) {
@@ -417,24 +452,83 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
                 });
                 item['inLibrary'] = inLibrary;
               }
+            } catch (e) {
+              print('📺 Error checking Sonarr library for trending: $e');
             }
-          } catch (e) {
-            print('📺 Error checking Sonarr library for trending: $e');
           }
         }
-      }
 
-      if (mounted) {
-        setState(() {
-          _trendingItems = items;
-          _precachedHeroBackdrops.clear();
-        });
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-          _precacheHeroImage(_currentHeroIndex);
-          _precacheHeroImage(_currentHeroIndex + 1);
-          _precacheHeroImage(_currentHeroIndex + 2);
-        });
+        if (mounted) {
+          setState(() {
+            _trendingMovies = movieItems;
+            _trendingTVShows = tvItems;
+            _trendingItems = []; // Clear unified list
+            _precachedHeroBackdrops.clear();
+          });
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            // Precache both movie and TV images
+            _precacheHeroImage(_currentMovieHeroIndex, isMovie: true);
+            _precacheHeroImage(_currentMovieHeroIndex + 1, isMovie: true);
+            _precacheHeroImage(_currentTVHeroIndex, isMovie: false);
+            _precacheHeroImage(_currentTVHeroIndex + 1, isMovie: false);
+          });
+        }
+      } else {
+        // Load unified list (original behavior)
+        final items = await TMDBApi.getTrending(
+          mediaType: 'all', // Can be 'movie', 'tv', or 'all'
+          timeWindow: _trendingTimeWindow,
+        );
+
+        // Check against Radarr library if available
+        if (mounted) {
+          final radarrState = context.read<RadarrState>();
+          if (radarrState.enabled && radarrState.movies != null) {
+            final movies = await radarrState.movies!;
+            for (final item in items) {
+              if (item['mediaType'] == 'movie') {
+                final tmdbId = item['tmdbId'] as int;
+                item['inLibrary'] = movies.any((m) => m.tmdbId == tmdbId);
+              }
+            }
+          }
+
+          // Check against Sonarr library if available
+          final sonarrState = context.read<SonarrState>();
+          if (sonarrState.enabled && sonarrState.api != null) {
+            try {
+              final sonarrSeries = await sonarrState.api!.series.getAll();
+              for (final item in items) {
+                if (item['mediaType'] == 'tv') {
+                  final title = item['title'] as String;
+                  // Check if this show is in Sonarr library by title match
+                  final inLibrary = sonarrSeries.any((series) {
+                    return series.title?.toLowerCase() == title.toLowerCase();
+                  });
+                  item['inLibrary'] = inLibrary;
+                }
+              }
+            } catch (e) {
+              print('📺 Error checking Sonarr library for trending: $e');
+            }
+          }
+        }
+
+        if (mounted) {
+          setState(() {
+            _trendingItems = items;
+            _trendingMovies = []; // Clear separate lists
+            _trendingTVShows = [];
+            _precachedHeroBackdrops.clear();
+          });
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            _precacheHeroImage(_currentHeroIndex);
+            _precacheHeroImage(_currentHeroIndex + 1);
+            _precacheHeroImage(_currentHeroIndex + 2);
+          });
+        }
       }
     } catch (e) {
       print('Failed to load trending: $e');
@@ -442,10 +536,18 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     }
   }
 
-  void _precacheHeroImage(int index) {
+  void _precacheHeroImage(int index, {bool? isMovie}) {
     if (!mounted) return;
-    if (index < 0 || index >= _trendingItems.length) return;
-    final url = _trendingItems[index]['backdrop'] as String?;
+
+    List<Map<String, dynamic>> items;
+    if (_filterHeroByTab && isMovie != null) {
+      items = isMovie ? _trendingMovies : _trendingTVShows;
+    } else {
+      items = _trendingItems;
+    }
+
+    if (index < 0 || index >= items.length) return;
+    final url = items[index]['backdrop'] as String?;
     if (url == null || url.isEmpty) return;
     if (_precachedHeroBackdrops.contains(url)) return;
     _precachedHeroBackdrops.add(url);
@@ -1695,6 +1797,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
           _heroCarousel(
             controller: _moviesHeroPageController,
             storageKey: 'discoverHeroCarouselMovies',
+            isMovieTab: true,
           ),
           // Content sections in custom order
           ..._buildMovieSections(),
@@ -1801,6 +1904,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
           _heroCarousel(
             controller: _tvHeroPageController,
             storageKey: 'discoverHeroCarouselTv',
+            isMovieTab: false,
           ),
           // TV shows sections in custom order
           ..._buildTVSections(),
@@ -4127,14 +4231,27 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   Widget _heroCarousel({
     required PageController controller,
     required String storageKey,
+    bool? isMovieTab,
   }) {
+    // Determine which list and index to use
+    final List<Map<String, dynamic>> items;
+    final int currentIndex;
+
+    if (_filterHeroByTab && isMovieTab != null) {
+      items = isMovieTab ? _trendingMovies : _trendingTVShows;
+      currentIndex = isMovieTab ? _currentMovieHeroIndex : _currentTVHeroIndex;
+    } else {
+      items = _trendingItems;
+      currentIndex = _currentHeroIndex;
+    }
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       if (controller.hasClients) {
         final currentPage =
             controller.page?.round() ?? controller.initialPage;
-        if (currentPage != _currentHeroIndex) {
-          controller.jumpToPage(_currentHeroIndex);
+        if (currentPage != currentIndex) {
+          controller.jumpToPage(currentIndex);
         }
       }
     });
@@ -4152,14 +4269,22 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
               controller: controller,
               onPageChanged: (index) {
                 setState(() {
-                  _currentHeroIndex = index;
+                  if (_filterHeroByTab && isMovieTab != null) {
+                    if (isMovieTab) {
+                      _currentMovieHeroIndex = index;
+                    } else {
+                      _currentTVHeroIndex = index;
+                    }
+                  } else {
+                    _currentHeroIndex = index;
+                  }
                 });
-                _precacheHeroImage(index + 1);
-                _precacheHeroImage(index - 1);
+                _precacheHeroImage(index + 1, isMovie: isMovieTab);
+                _precacheHeroImage(index - 1, isMovie: isMovieTab);
               },
-              itemCount: _trendingItems.length,
+              itemCount: items.length,
               itemBuilder: (context, index) {
-                final item = _trendingItems[index];
+                final item = items[index];
                 return GestureDetector(
                   onTap: () => _handleHeroTap(item),
                   child: Stack(
@@ -4285,13 +4410,13 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: List.generate(
-                _trendingItems.length,
+                items.length,
                 (index) => Container(
                   margin: const EdgeInsets.symmetric(horizontal: 4),
-                  width: _currentHeroIndex == index ? 24 : 8,
+                  width: currentIndex == index ? 24 : 8,
                   height: 8,
                   decoration: BoxDecoration(
-                    color: _currentHeroIndex == index
+                    color: currentIndex == index
                         ? Colors.white
                         : Colors.white.withOpacity(0.5),
                     borderRadius: BorderRadius.circular(4),

--- a/zagreus/lib/modules/discover/widgets/discover_sections_editor.dart
+++ b/zagreus/lib/modules/discover/widgets/discover_sections_editor.dart
@@ -65,6 +65,7 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
   int _columnsPerRow = 3;
   bool _showTitles = true;
   bool _monochromeRatings = false;
+  bool _filterHeroByTab = true;
   String _trendingTimeWindow = 'day';
 
   bool get hasChanges => _hasChanges;
@@ -125,6 +126,13 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
       _monochromeRatings = savedMonochromeRatings;
     }
 
+    // Load filter hero by tab setting
+    final savedFilterHeroByTab =
+        ZagreusDatabase.DISCOVER_FILTER_HERO_BY_TAB.read();
+    if (savedFilterHeroByTab != null) {
+      _filterHeroByTab = savedFilterHeroByTab;
+    }
+
     final savedTimeWindow =
         ZagreusDatabase.DISCOVER_TRENDING_TIME_WINDOW.read();
     if (savedTimeWindow == 'day' || savedTimeWindow == 'week') {
@@ -143,6 +151,7 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
     ZagreusDatabase.DISCOVER_COLUMNS_PER_ROW.update(_columnsPerRow);
     ZagreusDatabase.DISCOVER_SHOW_TITLES.update(_showTitles);
     ZagreusDatabase.DISCOVER_MONOCHROME_RATINGS.update(_monochromeRatings);
+    ZagreusDatabase.DISCOVER_FILTER_HERO_BY_TAB.update(_filterHeroByTab);
     ZagreusDatabase.DISCOVER_TRENDING_TIME_WINDOW
         .update(_trendingTimeWindow);
     setState(() => _hasChanges = false);
@@ -163,6 +172,7 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
           ((_columnsPerRowMin + _columnsPerRowMax) / 2).round();
       _showTitles = true;
       _monochromeRatings = false;
+      _filterHeroByTab = true;
       _trendingTimeWindow = 'day';
       _hasChanges = true;
     });
@@ -464,6 +474,44 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
           ),
           Text(
             'Display rating badges in white instead of colored. Restart required.',
+            style: TextStyle(
+              fontSize: 12,
+              color: theme.brightness == Brightness.dark
+                  ? Colors.white54
+                  : Colors.black45,
+            ),
+          ),
+          const SizedBox(height: 32),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Text(
+                  'Filter Hero Carousel by Tab',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: theme.brightness == Brightness.dark
+                        ? Colors.white
+                        : Colors.black87,
+                  ),
+                ),
+              ),
+              Switch(
+                value: _filterHeroByTab,
+                activeColor: ZagColours.accentColor(context),
+                onChanged: (value) {
+                  setState(() {
+                    _filterHeroByTab = value;
+                    _hasChanges = true;
+                  });
+                  widget.onHasChangesChanged?.call(_hasChanges);
+                },
+              ),
+            ],
+          ),
+          Text(
+            'When enabled, the hero carousel shows only movies on the Movies tab and only shows on the TV Shows tab. When disabled, it shows a unified catalog of both.',
             style: TextStyle(
               fontSize: 12,
               color: theme.brightness == Brightness.dark


### PR DESCRIPTION
- Add DISCOVER_FILTER_HERO_BY_TAB database setting (default: true)
- Update Edit Sections modal with new toggle in Config tab
- Modify _loadTrendingData to load separate movie and TV lists when filtering is enabled
- Update _heroCarousel widget to display appropriate content based on current tab
- Support both unified (all content) and split (movies on Movies tab, shows on Shows tab) modes
- Maintain same item count in both modes (10 items per tab when split, 10 items unified)
- Independent auto-scroll for each carousel when filtering is enabled