### PR TITLE
Apply calendar tab hiding to Discover module (premium Dashboard)

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -1311,15 +1311,17 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
 
   bool get _showLegacyModules =>
       ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read();
+  bool get _showCalendarTab => ZagreusDatabase.SHOW_CALENDAR_TAB.read();
   bool get _showAgentTab => ZagreusDatabase.SHOW_AGENT_TAB.read();
 
-  List<String> _discoverTabKeys({bool? showLegacyModules}) {
+  List<String> _discoverTabKeys({bool? showLegacyModules, bool? showCalendar}) {
     final includeModules = showLegacyModules ?? _showLegacyModules;
+    final includeCalendar = showCalendar ?? _showCalendarTab;
     return [
       if (includeModules) 'modules',
       'movies',
       'shows',
-      'calendar',
+      if (includeCalendar) 'calendar',
       'server',
     ];
   }
@@ -1359,6 +1361,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     return ZagBox.zagreus.listenableBuilder(
       selectItems: const [
         ZagreusDatabase.SHOW_LEGACY_MODULES_TAB,
+        ZagreusDatabase.SHOW_CALENDAR_TAB,
         ZagreusDatabase.SHOW_AGENT_TAB,
       ],
       builder: (context, _) => ZagScaffold(
@@ -1372,6 +1375,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
             : _DiscoverNavigationBar(
                 pageController: _pageController,
                 showLegacyModules: _showLegacyModules,
+                showCalendar: _showCalendarTab,
                 showAgentTab: _showAgentTab,
               ),
       ),
@@ -1380,15 +1384,16 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
 
   Widget _body() {
     final enableLegacyModules = _showLegacyModules;
+    final enableCalendar = _showCalendarTab;
     final showAgentTab = _showAgentTab;
     final tabs = ZagPageView(
-      key: ValueKey('discover_tabs_${enableLegacyModules}_$showAgentTab'),
+      key: ValueKey('discover_tabs_${enableLegacyModules}_${enableCalendar}_$showAgentTab'),
       controller: _pageController,
       children: [
         if (enableLegacyModules) _modulesPage(),
         _moviesPage(),
         _tvShowsPage(),
-        _calendarTab(),
+        if (enableCalendar) _calendarTab(),
         _serverTab(),
       ],
     );
@@ -1503,12 +1508,18 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
 
   List<Widget>? _buildAppBarActions() {
     final enableLegacyModules = _showLegacyModules;
+    final enableCalendar = _showCalendarTab;
     final showAgentTab = _showAgentTab;
     final modulesTabIndex = 0;
     final moviesTabIndex = enableLegacyModules ? 1 : 0;
     final showsTabIndex = enableLegacyModules ? 2 : 1;
-    final calendarIndex = enableLegacyModules ? 3 : 2;
-    final serverIndex = enableLegacyModules ? 4 : 3;
+
+    // Calculate calendar and server indices dynamically
+    int currentIndex = enableLegacyModules ? 3 : 2;
+    final calendarIndex = enableCalendar ? currentIndex : null;
+    if (enableCalendar) currentIndex++;
+    final serverIndex = currentIndex;
+
     final isMegaOrUltra = ZagreusMega.isEnabled || ZagreusUltra.isEnabled;
     final isPro = ZagreusPro.isEnabled;
 
@@ -1565,7 +1576,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       ];
     }
 
-    if (_currentPageIndex == calendarIndex) {
+    if (calendarIndex != null && _currentPageIndex == calendarIndex) {
       return [
         SwitchViewAction(
           pageController: _pageController,
@@ -7336,6 +7347,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
 class _DiscoverNavigationBar extends StatelessWidget {
   final PageController? pageController;
   final bool showLegacyModules;
+  final bool showCalendar;
   final bool showAgentTab;
 
   static final ScrollController modulesScrollController =
@@ -7350,6 +7362,7 @@ class _DiscoverNavigationBar extends StatelessWidget {
     Key? key,
     required this.pageController,
     required this.showLegacyModules,
+    required this.showCalendar,
     required this.showAgentTab,
   }) : super(key: key);
 
@@ -7359,7 +7372,7 @@ class _DiscoverNavigationBar extends StatelessWidget {
       if (showLegacyModules) Icons.workspaces_rounded,
       Icons.movie_rounded,
       Icons.tv_rounded,
-      Icons.calendar_today_rounded,
+      if (showCalendar) Icons.calendar_today_rounded,
       Icons.dns_rounded,
     ];
 
@@ -7367,7 +7380,7 @@ class _DiscoverNavigationBar extends StatelessWidget {
       if (showLegacyModules) 'Modules',
       'Movies',
       'Shows',
-      'Calendar',
+      if (showCalendar) 'Calendar',
       'Server',
     ];
 
@@ -7375,7 +7388,7 @@ class _DiscoverNavigationBar extends StatelessWidget {
       if (showLegacyModules) modulesScrollController,
       moviesScrollController,
       showsScrollController,
-      calendarScrollController,
+      if (showCalendar) calendarScrollController,
       ScrollController(),
     ];
 

--- a/zagreus/lib/modules/settings/routes/configuration_dashboard/pages/default_pages.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_dashboard/pages/default_pages.dart
@@ -91,6 +91,7 @@ class _State extends State<ConfigurationDashboardDefaultPagesRoute>
       selectItems: const [
         ZagreusDatabase.DISCOVER_DEFAULT_TAB,
         ZagreusDatabase.SHOW_LEGACY_MODULES_TAB,
+        ZagreusDatabase.SHOW_CALENDAR_TAB,
       ],
       builder: (context, _) {
         final options = _discoverTabOptions();
@@ -145,6 +146,7 @@ class _State extends State<ConfigurationDashboardDefaultPagesRoute>
 
   List<_DiscoverTabOption> _discoverTabOptions() {
     final showModules = ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read();
+    final showCalendar = ZagreusDatabase.SHOW_CALENDAR_TAB.read();
     final options = <_DiscoverTabOption>[];
     if (showModules) {
       options.add(
@@ -155,23 +157,24 @@ class _State extends State<ConfigurationDashboardDefaultPagesRoute>
         ),
       );
     }
-    options.addAll(const [
-      _DiscoverTabOption(
+    options.addAll([
+      const _DiscoverTabOption(
         key: 'movies',
         label: 'Movies',
         icon: Icons.movie_rounded,
       ),
-      _DiscoverTabOption(
+      const _DiscoverTabOption(
         key: 'shows',
         label: 'Shows',
         icon: Icons.tv_rounded,
       ),
-      _DiscoverTabOption(
-        key: 'calendar',
-        label: 'Calendar',
-        icon: Icons.calendar_today_rounded,
-      ),
-      _DiscoverTabOption(
+      if (showCalendar)
+        const _DiscoverTabOption(
+          key: 'calendar',
+          label: 'Calendar',
+          icon: Icons.calendar_today_rounded,
+        ),
+      const _DiscoverTabOption(
         key: 'server',
         label: 'Server',
         icon: Icons.dns_rounded,


### PR DESCRIPTION
Extended the calendar tab hiding functionality to also work with the Discover module, which is the premium replacement for the Dashboard. Both modules now respect the SHOW_CALENDAR_TAB setting.

Changes:
- Added _showCalendarTab getter in Discover route
- Updated _discoverTabKeys to conditionally include calendar
- Updated Discover navigation bar to accept showCalendar parameter
- Conditionally render calendar tab in page view
- Updated app bar actions to handle dynamic calendar index
- Updated default page settings to exclude calendar when hidden

The implementation ensures both Dashboard (free) and Discover (Pro) modules work consistently with the calendar visibility setting.