### PR TITLE
Separate Modules tab visibility for Dashboard and Discover

### DIFF
--- a/zagreus/lib/database/tables/zagreus.dart
+++ b/zagreus/lib/database/tables/zagreus.dart
@@ -118,7 +118,8 @@ enum ZagreusDatabase<T> with ZagTableMixin<T> {
   DISCOVER_TRENDING_TIME_WINDOW<String>('day'),
   DISCOVER_FILTER_HERO_BY_TAB<bool>(true),
   DISCOVER_DEFAULT_TAB<String>('movies'),
-  SHOW_LEGACY_MODULES_TAB<bool>(false),
+  DASHBOARD_SHOW_MODULES_TAB<bool>(true),
+  DISCOVER_SHOW_MODULES_TAB<bool>(false),
   SHOW_CALENDAR_TAB<bool>(true),
   SHOW_AGENT_TAB<bool>(true);
 

--- a/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
@@ -75,14 +75,14 @@ class _State extends State<DashboardRoute> {
 
   int _getVisiblePageCount() {
     int count = 0;
-    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) count++;
+    if (ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.read()) count++;
     if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) count++;
     return count;
   }
 
   List<Widget> _getVisiblePages() {
     final List<Widget> pages = [];
-    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+    if (ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.read()) {
       pages.add(ModulesPage(key: ValueKey(ZagreusDatabase.ENABLED_PROFILE.read())));
     }
     if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
@@ -93,12 +93,12 @@ class _State extends State<DashboardRoute> {
 
   int? _getVisiblePageIndex(int absoluteIndex) {
     // Maps absolute page indices (0 = modules, 1 = calendar) to visible page indices
-    if (absoluteIndex == 0 && ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+    if (absoluteIndex == 0 && ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.read()) {
       return 0; // Modules is always first if visible
     }
     if (absoluteIndex == 1 && ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
       // Calendar is second if modules is visible, first otherwise
-      return ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read() ? 1 : 0;
+      return ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.read() ? 1 : 0;
     }
     return null; // Page is not visible
   }
@@ -253,7 +253,7 @@ class _State extends State<DashboardRoute> {
 
   Widget _body() {
     final mainContent = ZagreusDatabase.ENABLED_PROFILE.listenableBuilder(
-      builder: (context, _) => ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.listenableBuilder(
+      builder: (context, _) => ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.listenableBuilder(
         builder: (context, _) => ZagreusDatabase.SHOW_CALENDAR_TAB.listenableBuilder(
           builder: (context, _) {
             final visiblePages = _getVisiblePages();

--- a/zagreus/lib/modules/dashboard/routes/dashboard/widgets/navigation_bar.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/widgets/navigation_bar.dart
@@ -27,7 +27,7 @@ class HomeNavigationBar extends StatelessWidget {
 
   static List<String> getVisibleTitles() {
     final List<String> visibleTitles = [];
-    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+    if (ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.read()) {
       visibleTitles.add(_allTitles[0]);
     }
     if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
@@ -38,7 +38,7 @@ class HomeNavigationBar extends StatelessWidget {
 
   static List<IconData> getVisibleIcons() {
     final List<IconData> visibleIcons = [];
-    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+    if (ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.read()) {
       visibleIcons.add(_allIcons[0]);
     }
     if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
@@ -49,7 +49,7 @@ class HomeNavigationBar extends StatelessWidget {
 
   static List<ScrollController> getVisibleScrollControllers() {
     final List<ScrollController> visibleControllers = [];
-    if (ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read()) {
+    if (ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.read()) {
       visibleControllers.add(scrollControllers[0]);
     }
     if (ZagreusDatabase.SHOW_CALENDAR_TAB.read()) {
@@ -60,7 +60,7 @@ class HomeNavigationBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.listenableBuilder(
+    return ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.listenableBuilder(
       builder: (context, _) => ZagreusDatabase.SHOW_CALENDAR_TAB.listenableBuilder(
         builder: (context, _) {
           final visibleTitles = getVisibleTitles();

--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -1412,7 +1412,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   }
 
   bool get _showLegacyModules =>
-      ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read();
+      ZagreusDatabase.DISCOVER_SHOW_MODULES_TAB.read();
   bool get _showCalendarTab => ZagreusDatabase.SHOW_CALENDAR_TAB.read();
   bool get _showAgentTab => ZagreusDatabase.SHOW_AGENT_TAB.read();
 
@@ -1462,7 +1462,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
 
     return ZagBox.zagreus.listenableBuilder(
       selectItems: const [
-        ZagreusDatabase.SHOW_LEGACY_MODULES_TAB,
+        ZagreusDatabase.DISCOVER_SHOW_MODULES_TAB,
         ZagreusDatabase.SHOW_CALENDAR_TAB,
         ZagreusDatabase.SHOW_AGENT_TAB,
       ],

--- a/zagreus/lib/modules/settings/routes/configuration_dashboard/pages/default_pages.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_dashboard/pages/default_pages.dart
@@ -52,7 +52,7 @@ class _State extends State<ConfigurationDashboardDefaultPagesRoute>
   Widget _dashboardDefaultPageTile() {
     const _db = DashboardDatabase.NAVIGATION_INDEX;
     return _db.listenableBuilder(
-      builder: (context, _) => ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.listenableBuilder(
+      builder: (context, _) => ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB.listenableBuilder(
         builder: (context, _) => ZagreusDatabase.SHOW_CALENDAR_TAB.listenableBuilder(
           builder: (context, _) {
             final visibleTitles = HomeNavigationBar.getVisibleTitles();
@@ -90,7 +90,7 @@ class _State extends State<ConfigurationDashboardDefaultPagesRoute>
     return ZagBox.zagreus.listenableBuilder(
       selectItems: const [
         ZagreusDatabase.DISCOVER_DEFAULT_TAB,
-        ZagreusDatabase.SHOW_LEGACY_MODULES_TAB,
+        ZagreusDatabase.DISCOVER_SHOW_MODULES_TAB,
         ZagreusDatabase.SHOW_CALENDAR_TAB,
       ],
       builder: (context, _) {
@@ -145,7 +145,7 @@ class _State extends State<ConfigurationDashboardDefaultPagesRoute>
   }
 
   List<_DiscoverTabOption> _discoverTabOptions() {
-    final showModules = ZagreusDatabase.SHOW_LEGACY_MODULES_TAB.read();
+    final showModules = ZagreusDatabase.DISCOVER_SHOW_MODULES_TAB.read();
     final showCalendar = ZagreusDatabase.SHOW_CALENDAR_TAB.read();
     final options = <_DiscoverTabOption>[];
     if (showModules) {

--- a/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
@@ -105,13 +105,40 @@ class _State extends State<ConfigurationNavigationRoute>
 
   Widget _legacyModulesTabToggle() {
     if (!ZagreusPro.isEnabled) return const SizedBox.shrink();
-    const db = ZagreusDatabase.SHOW_LEGACY_MODULES_TAB;
+    return Column(
+      children: [
+        _dashboardModulesTabToggle(),
+        _discoverModulesTabToggle(),
+      ],
+    );
+  }
+
+  Widget _dashboardModulesTabToggle() {
+    const db = ZagreusDatabase.DASHBOARD_SHOW_MODULES_TAB;
     return db.listenableBuilder(
       builder: (context, _) => ZagBlock(
-        title: 'Hide Modules Tab',
+        title: 'Hide Modules Tab (Dashboard)',
         body: const [
           TextSpan(
             text: 'Hides Modules tab in Dashboard',
+          ),
+        ],
+        trailing: ZagSwitch(
+          value: !db.read(),
+          onChanged: (value) => db.update(!value),
+        ),
+      ),
+    );
+  }
+
+  Widget _discoverModulesTabToggle() {
+    const db = ZagreusDatabase.DISCOVER_SHOW_MODULES_TAB;
+    return db.listenableBuilder(
+      builder: (context, _) => ZagBlock(
+        title: 'Hide Modules Tab (Discover)',
+        body: const [
+          TextSpan(
+            text: 'Hides Modules tab in Discover',
           ),
         ],
         trailing: ZagSwitch(


### PR DESCRIPTION
Created independent controls for Modules tab visibility:
- DASHBOARD_SHOW_MODULES_TAB (default: true) - Modules shown in Dashboard
- DISCOVER_SHOW_MODULES_TAB (default: false) - Modules hidden in Discover

This allows different default behaviors:
- Dashboard (free users): Modules tab enabled by default
- Discover (premium users): Modules tab disabled by default

Settings UI now shows two separate toggles:
- "Hide Modules Tab (Dashboard)" - Controls Dashboard modules visibility
- "Hide Modules Tab (Discover)" - Controls Discover modules visibility

Both toggles are Pro-only features and can be configured independently.