### PR TITLE
Add recently released movies to dashboard

### DIFF
--- a/zagreus/lib/modules/discover/core/tmdb_api.dart
+++ b/zagreus/lib/modules/discover/core/tmdb_api.dart
@@ -176,6 +176,73 @@ class TMDBApi {
     }
   }
 
+  static Future<List<Map<String, dynamic>>> getRecentlyReleasedMovies({
+    int page = 1,
+    String? region,
+  }) async {
+    try {
+      // Calculate date range: 2 months ago to today
+      final now = DateTime.now();
+      final twoMonthsAgo = DateTime(now.year, now.month - 2, now.day);
+      final startDate = '${twoMonthsAgo.year}-${twoMonthsAgo.month.toString().padLeft(2, '0')}-${twoMonthsAgo.day.toString().padLeft(2, '0')}';
+      final endDate = '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+
+      // Use discover endpoint with filters for recently released theatrical movies
+      String url = '$_baseUrl/discover/movie?api_key=$_apiKey&page=$page';
+      url += '&with_release_type=4'; // Theatrical releases only
+      url += '&sort_by=release_date.desc'; // Newest first
+      url += '&vote_count.gte=10'; // Minimum 10 votes for quality
+      url += '&primary_release_date.gte=$startDate'; // Start date (2 months ago)
+      url += '&release_date.lte=$endDate'; // End date (today)
+
+      if (region != null) {
+        url += '&region=$region';
+      } else {
+        url += '&region=US'; // Default to US
+      }
+
+      final response = await http.get(Uri.parse(url));
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final results = data['results'] as List;
+
+        // Transform and sort by release date (newest first)
+        final movies = results.map((item) {
+          return {
+            'id': item['id'],
+            'title': item['title'] ?? 'Unknown',
+            'backdrop': getImageUrl(item['backdrop_path']),
+            'poster': getImageUrl(item['poster_path'], size: 'w500'),
+            'rating': (item['vote_average'] ?? 0).toDouble(),
+            'overview': item['overview'] ?? '',
+            'releaseDate': item['release_date'],
+            'mediaType': 'movie',
+            'tmdbId': item['id'],
+            'popularity': item['popularity'] ?? 0,
+            'voteCount': item['vote_count'] ?? 0,
+            'inLibrary': false,
+          };
+        }).toList();
+
+        // Sort by release date (newest first)
+        movies.sort((a, b) {
+          final aDate = a['releaseDate'] as String?;
+          final bDate = b['releaseDate'] as String?;
+          if (aDate == null || bDate == null) return 0;
+          return bDate.compareTo(aDate);
+        });
+
+        return movies;
+      }
+
+      throw Exception('Failed to load recently released movies: ${response.statusCode}');
+    } catch (e) {
+      print('TMDB API Error (Recently Released Movies): $e');
+      return [];
+    }
+  }
+
   static Future<List<Map<String, dynamic>>> getPopularTVShows({
     int page = 1,
     String? region,

--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -23,6 +23,7 @@ import 'package:zagreus/modules/discover/routes/downloading_soon/route.dart';
 import 'package:zagreus/modules/discover/routes/missing/route.dart';
 import 'package:zagreus/modules/discover/routes/recommended/route.dart';
 import 'package:zagreus/modules/discover/routes/tmdb_popular_movies/route.dart';
+import 'package:zagreus/modules/discover/routes/tmdb_recently_released_movies/route.dart';
 import 'package:zagreus/modules/discover/routes/tmdb_popular_tv_shows/route.dart';
 import 'package:zagreus/modules/discover/routes/tmdb_trending_new_tv_shows/route.dart';
 import 'package:zagreus/modules/discover/routes/tmdb_popular_people/route.dart';
@@ -102,6 +103,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   static const _scrollIdMissing = 'missing_movies_section';
   static const _scrollIdDownloadingSoon = 'downloading_soon_section';
   static const _scrollIdPopularMovies = 'popular_movies_section';
+  static const _scrollIdRecentlyReleasedMovies = 'recently_released_movies_section';
   static const _scrollIdPopularTv = 'popular_tv_shows_section';
   static const _scrollIdTrendingTv = 'trending_tv_shows_section';
   static const _scrollIdMostAnticipatedShows =
@@ -121,6 +123,8 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       PageStorageKey<String>('discover_downloading_soon');
   static const _popularMoviesListKey =
       PageStorageKey<String>('discover_popular_movies');
+  static const _recentlyReleasedMoviesListKey =
+      PageStorageKey<String>('discover_recently_released_movies');
   static const _popularTvShowsListKey =
       PageStorageKey<String>('discover_popular_tv_shows');
   static const _trendingTvShowsListKey =
@@ -163,6 +167,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   List<RadarrMovie> _missingMovies = [];
   List<RadarrMovie> _downloadingSoon = [];
   List<Map<String, dynamic>> _popularMovies = [];
+  List<Map<String, dynamic>> _recentlyReleasedMovies = [];
   List<Map<String, dynamic>> _popularTVShows = [];
   List<Map<String, dynamic>> _trendingNewTVShows = [];
   List<Map<String, dynamic>> _mostAnticipatedShows = [];
@@ -259,6 +264,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     super.didChangeDependencies();
     // Load popular movies and people here where we can access Localizations
     _loadPopularMovies();
+    _loadRecentlyReleasedMovies();
     _loadPopularTVShows();
     _loadTrendingNewTVShows();
     _loadMostAnticipatedShows();
@@ -851,6 +857,39 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       }
     } catch (e) {
       print('❌ Error loading popular movies: $e');
+    }
+  }
+
+  Future<void> _loadRecentlyReleasedMovies() async {
+    print('🎬 Loading recently released movies...');
+    try {
+      // Get user's region from locale
+      final locale = Localizations.localeOf(context);
+      final region = locale.countryCode ?? 'US';
+      print('🎬 Using region: $region');
+
+      final movies = await TMDBApi.getRecentlyReleasedMovies(region: region);
+      print('🎬 Got ${movies.length} recently released movies from TMDB');
+
+      // Check against Radarr library if available
+      final radarrState = context.read<RadarrState>();
+      if (radarrState.enabled && radarrState.movies != null) {
+        final radarrMovies = await radarrState.movies!;
+        for (final movie in movies) {
+          final tmdbId = movie['tmdbId'] as int;
+          movie['inLibrary'] = radarrMovies.any((m) => m.tmdbId == tmdbId);
+        }
+      }
+
+      if (mounted) {
+        setState(() {
+          _recentlyReleasedMovies =
+              movies.take(10).toList(); // Limit to 10 for the section
+        });
+        print('🎬 Set ${_recentlyReleasedMovies.length} recently released movies in state');
+      }
+    } catch (e) {
+      print('❌ Error loading recently released movies: $e');
     }
   }
 
@@ -1827,6 +1866,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       'missing',
       'downloading_soon',
       'popular_movies',
+      'recently_released_movies',
       'most_anticipated_movies',
       'popular_people',
       'deep_cuts',
@@ -1868,6 +1908,10 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
           ]),
       'popular_movies': () => Column(children: [
             _popularMoviesSection(),
+            if (_showTitles) const SizedBox(height: 4)
+          ]),
+      'recently_released_movies': () => Column(children: [
+            _recentlyReleasedMoviesSection(),
             if (_showTitles) const SizedBox(height: 4)
           ]),
       'most_anticipated_movies': () =>
@@ -4903,6 +4947,240 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   }
 
   Future<void> _handlePopularMovieTap(Map<String, dynamic> movie) async {
+    final bool inLibrary = movie['inLibrary'] ?? false;
+    final int? serviceItemId = movie['serviceItemId'] as int?;
+    final int? tmdbId = movie['tmdbId'] as int?;
+
+    if (inLibrary && serviceItemId != null) {
+      RadarrRoutes.MOVIE.go(
+        params: {
+          'movie': serviceItemId.toString(),
+        },
+      );
+      return;
+    }
+
+    if (tmdbId == null) {
+      showZagSnackBar(
+        title: movie['title'] ?? 'Movie',
+        message: 'Missing TMDB identifier for this title.',
+        type: ZagSnackbarType.ERROR,
+      );
+      return;
+    }
+
+    await _openMovieInRadarr(
+      tmdbId: tmdbId,
+      title: movie['title'] as String?,
+    );
+  }
+
+  Widget _recentlyReleasedMoviesSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Section title
+        _sectionTitleRow(
+          context: context,
+          leadingIcon: Icons.new_releases_rounded,
+          leadingIconColor: const Color(0xFF6688FF),
+          moduleLabel: 'TMDB',
+          moduleLabelColor: const Color(0xFF6688FF),
+          title: 'Recently Released',
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+          onTap: _recentlyReleasedMovies.isNotEmpty
+              ? () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => TMDBRecentlyReleasedMoviesRoute(
+                        initialData: _recentlyReleasedMovies,
+                      ),
+                    ),
+                  );
+                }
+              : null,
+          onLongPress: () => _refreshSection(
+            scrollKey: _scrollIdRecentlyReleasedMovies,
+            loader: _loadRecentlyReleasedMovies,
+            sectionLabel: 'Recently Released Movies',
+          ),
+          showArrow: _recentlyReleasedMovies.isNotEmpty,
+        ),
+        // Movie list or loading placeholder
+        _recentlyReleasedMovies.isNotEmpty
+            ? SizedBox(
+                height: _posterListHeight,
+                child: ListView.builder(
+                  key: _recentlyReleasedMoviesListKey,
+                  controller:
+                      _sectionScrollController(_scrollIdRecentlyReleasedMovies),
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  itemCount: _recentlyReleasedMovies.length,
+                  itemBuilder: (context, index) {
+                    final movie = _recentlyReleasedMovies[index];
+                    return _recentlyReleasedMovieCard(movie);
+                  },
+                ),
+              )
+            : Container(
+                height: _posterHeight,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Center(
+                  child: Text(
+                    'Loading recently released movies...',
+                    style: TextStyle(
+                      color: (Theme.of(context).brightness == Brightness.dark
+                              ? Colors.white
+                              : Colors.black)
+                          .withOpacity(0.5),
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+              ),
+      ],
+    );
+  }
+
+  Widget _recentlyReleasedMovieCard(Map<String, dynamic> movie) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 12),
+      child: GestureDetector(
+        onTap: () {
+          // Could navigate to a detail view or add to Radarr
+          _handleRecentlyReleasedMovieTap(movie);
+        },
+        child: Container(
+          width: _posterWidth,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Movie poster
+              Stack(
+                children: [
+                  Container(
+                    height: _posterHeight,
+                    width: _posterWidth,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(8),
+                      color: Colors.grey.shade800,
+                    ),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Image.network(
+                        movie['poster'] ?? '',
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) {
+                          return Center(
+                            child: Icon(
+                              Icons.movie_rounded,
+                              size: 40,
+                              color: Colors.grey.shade600,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  // In library badge
+                  if (movie['inLibrary'] == true)
+                    Positioned(
+                      top: 10,
+                      right: 10,
+                      child: Container(
+                        width: 11,
+                        height: 11,
+                        decoration: BoxDecoration(
+                          color: ZagColours.orange,
+                          shape: BoxShape.circle,
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withOpacity(0.6),
+                              blurRadius: 4,
+                              offset: const Offset(0, 2),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  // Rating badge - top left
+                  if (movie['rating'] != null && movie['rating'] > 0)
+                    Positioned(
+                      top: 8,
+                      left: 8,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: Colors.black.withOpacity(0.7),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text(
+                          (movie['rating'] as num).toStringAsFixed(1),
+                          style: TextStyle(
+                            color: _ratingColor(
+                                (movie['rating'] as num).toDouble()),
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ),
+                  // Gradient overlay
+                  if (ZagreusDatabase.DISCOVER_SHOW_TITLES.read())
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Container(
+                        height: _posterHeight,
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              Colors.transparent,
+                              Colors.transparent,
+                              Colors.black.withOpacity(0.8),
+                            ],
+                            stops: const [0.0, 0.5, 1.0],
+                          ),
+                        ),
+                      ),
+                    ),
+                  // Title overlay
+                  if (ZagreusDatabase.DISCOVER_SHOW_TITLES.read())
+                    Positioned(
+                      bottom: 8,
+                      left: 8,
+                      right: 8,
+                      child: Text(
+                        movie['title'] ?? 'Unknown',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: _moduleSectionTitleFontSize - 4,
+                          fontWeight: FontWeight.bold,
+                          shadows: const [
+                            Shadow(
+                              color: Colors.black,
+                              blurRadius: 4,
+                            ),
+                          ],
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleRecentlyReleasedMovieTap(Map<String, dynamic> movie) async {
     final bool inLibrary = movie['inLibrary'] ?? false;
     final int? serviceItemId = movie['serviceItemId'] as int?;
     final int? tmdbId = movie['tmdbId'] as int?;

--- a/zagreus/lib/modules/discover/routes/tmdb_recently_released_movies/route.dart
+++ b/zagreus/lib/modules/discover/routes/tmdb_recently_released_movies/route.dart
@@ -1,0 +1,929 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:zagreus/core.dart';
+import 'package:zagreus/modules/discover/core/tmdb_api.dart';
+import 'package:zagreus/modules/radarr.dart';
+import 'package:zagreus/router/routes/radarr.dart';
+import 'package:zagreus/database/tables/zagreus.dart';
+
+class TMDBRecentlyReleasedMoviesRoute extends StatefulWidget {
+  final List<Map<String, dynamic>>? initialData;
+
+  const TMDBRecentlyReleasedMoviesRoute({
+    Key? key,
+    this.initialData,
+  }) : super(key: key);
+
+  @override
+  State<TMDBRecentlyReleasedMoviesRoute> createState() => _State();
+}
+
+class _State extends State<TMDBRecentlyReleasedMoviesRoute>
+    with ZagScrollControllerMixin {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  List<Map<String, dynamic>> _movies = [];
+  bool _isLoading = true;
+  String? _error;
+  int _currentPage = 1;
+  bool _hasMorePages = true;
+  bool _isLoadingMore = false;
+
+  // Radarr multi-add settings
+  int? _radarrQualityProfileId;
+  String? _radarrQualityProfileName;
+  String? _radarrRootFolder;
+  bool _radarrSearchForMissing = true;
+
+  // Multi-select mode
+  bool _isMultiSelectMode = false;
+  Set<int> _selectedMovieIndices = {};
+
+  int get _titleMaxLines {
+    return 3;
+  }
+
+  double get _titleFontSize {
+    final savedColumns = ZagreusDatabase.DISCOVER_COLUMNS_PER_ROW.read() ?? 3;
+    return savedColumns == 2 ? 12.0 : (savedColumns == 4 ? 16.0 : 14.0);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSavedSettings();
+    if (widget.initialData?.isNotEmpty == true) {
+      _movies = List<Map<String, dynamic>>.from(widget.initialData!);
+      _isLoading = false;
+      Future.microtask(() {
+        if (mounted) {
+          _loadRecentlyReleasedMovies(silent: true);
+        }
+      });
+    } else {
+      _loadRecentlyReleasedMovies();
+    }
+
+    // Add scroll listener for pagination
+    scrollController.addListener(_scrollListener);
+  }
+
+  void _loadSavedSettings() {
+    _radarrQualityProfileId = ZagreusDatabase.Z_ASSISTANT_RADARR_QUALITY_PROFILE_ID.read();
+    _radarrQualityProfileName = ZagreusDatabase.Z_ASSISTANT_RADARR_QUALITY_PROFILE_NAME.read();
+    _radarrRootFolder = ZagreusDatabase.Z_ASSISTANT_RADARR_ROOT_FOLDER.read();
+    _radarrSearchForMissing = ZagreusDatabase.Z_ASSISTANT_RADARR_SEARCH_FOR_MISSING.read();
+  }
+
+  @override
+  void dispose() {
+    scrollController.removeListener(_scrollListener);
+    super.dispose();
+  }
+
+  void _scrollListener() {
+    if (scrollController.position.pixels >=
+        scrollController.position.maxScrollExtent - 200) {
+      if (!_isLoadingMore && _hasMorePages) {
+        _loadMoreMovies();
+      }
+    }
+  }
+
+  Color _ratingColor(double rating) {
+    final monochrome = ZagreusDatabase.DISCOVER_MONOCHROME_RATINGS.read();
+    if (monochrome) {
+      return Colors.white;
+    }
+
+    if (rating >= 8.0) {
+      return const Color(0xFF64B5F6); // Pastel blue
+    } else if (rating >= 6.0) {
+      final progress = (rating - 6.0) / 2.0;
+      final hue = 0.15 + progress * 0.15;
+      return HSVColor.fromAHSV(1.0, hue * 360, 0.8, 0.9).toColor();
+    } else if (rating >= 5.0) {
+      return Colors.orange;
+    } else {
+      return Colors.red;
+    }
+  }
+
+  Future<void> _loadRecentlyReleasedMovies({bool silent = false}) async {
+    if (!silent) {
+      setState(() {
+        _isLoading = true;
+        _error = null;
+      });
+    } else {
+      _error = null;
+    }
+
+    try {
+      // Get user's region from locale
+      final locale = Localizations.localeOf(context);
+      final region = locale.countryCode ?? 'US';
+
+      final movies = await TMDBApi.getRecentlyReleasedMovies(page: 1, region: region);
+
+      // Check against Radarr library if available
+      final radarrState = context.read<RadarrState>();
+      if (radarrState.enabled && radarrState.api != null) {
+        try {
+          radarrState.fetchMovies();
+          final radarrMovies = await radarrState.movies!;
+
+          for (final movie in movies) {
+            final tmdbId = movie['tmdbId'] as int?;
+            final title = movie['title'] as String;
+
+            // Check if this movie is in Radarr library
+            final inLibrary = radarrMovies.any((radarrMovie) {
+              if (tmdbId != null && radarrMovie.tmdbId == tmdbId) {
+                return true;
+              }
+              return radarrMovie.title?.toLowerCase() == title.toLowerCase();
+            });
+            movie['inLibrary'] = inLibrary;
+
+            if (inLibrary) {
+              final radarrMovie = radarrMovies.firstWhere(
+                (m) =>
+                    (tmdbId != null && m.tmdbId == tmdbId) ||
+                    m.title?.toLowerCase() == title.toLowerCase(),
+              );
+              movie['serviceItemId'] = radarrMovie.id;
+            }
+          }
+        } catch (e) {
+          print('Failed to check Radarr library: $e');
+        }
+      }
+
+      if (!mounted) return;
+      setState(() {
+        _movies = movies;
+        _isLoading = false;
+        _currentPage = 1;
+        _hasMorePages = movies.isNotEmpty;
+        _error = null;
+      });
+    } catch (error, stack) {
+      ZagLogger().error('Failed to load recently released movies', error, stack);
+      if (!mounted) return;
+      if (silent && _movies.isNotEmpty) {
+        return;
+      }
+      setState(() {
+        _error = error.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _loadMoreMovies() async {
+    if (_isLoadingMore) return;
+
+    setState(() {
+      _isLoadingMore = true;
+    });
+
+    try {
+      final locale = Localizations.localeOf(context);
+      final region = locale.countryCode ?? 'US';
+
+      final nextPage = _currentPage + 1;
+      final movies =
+          await TMDBApi.getRecentlyReleasedMovies(page: nextPage, region: region);
+
+      // Check against Radarr library if available
+      final radarrState = context.read<RadarrState>();
+      if (radarrState.enabled && radarrState.api != null) {
+        try {
+          final radarrMovies = await radarrState.movies!;
+
+          for (final movie in movies) {
+            final tmdbId = movie['tmdbId'] as int?;
+            final title = movie['title'] as String;
+
+            final inLibrary = radarrMovies.any((radarrMovie) {
+              if (tmdbId != null && radarrMovie.tmdbId == tmdbId) {
+                return true;
+              }
+              return radarrMovie.title?.toLowerCase() == title.toLowerCase();
+            });
+            movie['inLibrary'] = inLibrary;
+
+            if (inLibrary) {
+              final radarrMovie = radarrMovies.firstWhere(
+                (m) =>
+                    (tmdbId != null && m.tmdbId == tmdbId) ||
+                    m.title?.toLowerCase() == title.toLowerCase(),
+              );
+              movie['serviceItemId'] = radarrMovie.id;
+            }
+          }
+        } catch (e) {
+          print('Failed to check Radarr library: $e');
+        }
+      }
+
+      setState(() {
+        _movies.addAll(movies);
+        _currentPage = nextPage;
+        _hasMorePages = movies.isNotEmpty;
+        _isLoadingMore = false;
+      });
+    } catch (error) {
+      setState(() {
+        _isLoadingMore = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ZagScaffold(
+      scaffoldKey: _scaffoldKey,
+      appBar: _appBar(),
+      body: _body(),
+    );
+  }
+
+  PreferredSizeWidget _appBar() {
+    if (_isMultiSelectMode) {
+      return AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () {
+            setState(() {
+              _isMultiSelectMode = false;
+              _selectedMovieIndices.clear();
+            });
+          },
+        ),
+        title: Text('${_selectedMovieIndices.length} selected'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.select_all),
+            onPressed: _toggleSelectAll,
+            tooltip: 'Select All',
+          ),
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: _selectedMovieIndices.isEmpty ? null : _addSelectedMoviesToRadarr,
+            tooltip: 'Add Selected',
+          ),
+        ],
+      );
+    }
+
+    return ZagAppBar(
+      title: 'Recently Released Movies',
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.tune),
+          onPressed: _showRadarrConfig,
+          tooltip: 'Radarr Settings',
+        ),
+        IconButton(
+          icon: const Icon(Icons.checklist),
+          onPressed: () {
+            setState(() {
+              _isMultiSelectMode = true;
+            });
+          },
+          tooltip: 'Multi-Select',
+        ),
+        IconButton(
+          icon: Icon(ZagIcons.REFRESH),
+          onPressed: _loadRecentlyReleasedMovies,
+        ),
+      ],
+    );
+  }
+
+  void _toggleSelectAll() {
+    setState(() {
+      if (_selectedMovieIndices.length == _movies.length) {
+        _selectedMovieIndices.clear();
+      } else {
+        _selectedMovieIndices = Set.from(List.generate(_movies.length, (i) => i));
+      }
+    });
+  }
+
+  Widget _body() {
+    if (_isLoading) {
+      return Center(
+        child: ZagLoader(),
+      );
+    }
+
+    if (_error != null && _movies.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 64,
+              color: Colors.red,
+            ),
+            SizedBox(height: 16),
+            Text(
+              'Error Loading Recently Released Movies',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            SizedBox(height: 8),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                _error!,
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Colors.grey),
+              ),
+            ),
+            SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _loadRecentlyReleasedMovies,
+              child: Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_movies.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.movie_outlined,
+              size: 64,
+              color: Colors.grey,
+            ),
+            SizedBox(height: 16),
+            Text(
+              'No Recently Released Movies Found',
+              style: TextStyle(
+                fontSize: 18,
+                color: Colors.grey,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final savedColumns = ZagreusDatabase.DISCOVER_COLUMNS_PER_ROW.read() ?? 3;
+    final usesThreeColumns = savedColumns == 3;
+    final horizontalPadding = usesThreeColumns ? 20.0 : 16.0;
+    final gridSpacing = usesThreeColumns ? 16.0 : 12.0;
+
+    return RefreshIndicator(
+      onRefresh: _loadRecentlyReleasedMovies,
+      child: GridView.builder(
+        controller: scrollController,
+        padding: EdgeInsets.symmetric(
+          horizontal: horizontalPadding,
+          vertical: 20,
+        ),
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: savedColumns,
+          childAspectRatio: 0.58,
+          crossAxisSpacing: gridSpacing,
+          mainAxisSpacing: gridSpacing,
+        ),
+        itemCount: _movies.length + (_isLoadingMore ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index == _movies.length) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: CircularProgressIndicator(),
+              ),
+            );
+          }
+          return _movieTile(_movies[index], index);
+        },
+      ),
+    );
+  }
+
+  Widget _movieTile(Map<String, dynamic> movie, int index) {
+    final bool inLibrary = movie['inLibrary'] ?? false;
+    final int? serviceItemId = movie['serviceItemId'] as int?;
+    final int? tmdbId = movie['tmdbId'] as int?;
+    final isSelected = _selectedMovieIndices.contains(index);
+
+    return GestureDetector(
+      onTap: () => _isMultiSelectMode
+          ? _toggleSelection(index)
+          : _handleMovieTap(
+              inLibrary: inLibrary,
+              serviceItemId: serviceItemId,
+              tmdbId: tmdbId,
+              title: movie['title'] as String?,
+            ),
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: Colors.grey.shade800,
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              // Poster
+              _buildPosterImage(movie),
+              // Gradient overlay
+              if (ZagreusDatabase.DISCOVER_SHOW_TITLES.read())
+                Container(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        Colors.transparent,
+                        Colors.transparent,
+                        Colors.black.withOpacity(0.8),
+                      ],
+                      stops: [0.0, 0.5, 1.0],
+                    ),
+                  ),
+                ),
+              // Library indicator dot - top right
+              if (inLibrary)
+                Positioned(
+                  top: 10,
+                  right: 10,
+                  child: Container(
+                    width: 11,
+                    height: 11,
+                    decoration: BoxDecoration(
+                      color: ZagColours.orange,
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.6),
+                          blurRadius: 4,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              // Rating badge - top left
+              if (movie['rating'] != null && movie['rating'] > 0)
+                Positioned(
+                  top: 8,
+                  left: 8,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withOpacity(0.7),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: Text(
+                      (movie['rating'] ?? 0.0).toStringAsFixed(1),
+                      style: TextStyle(
+                        color: _ratingColor((movie['rating'] ?? 0.0).toDouble()),
+                        fontSize: 10,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              // Selection indicator
+              if (_isMultiSelectMode)
+                Positioned(
+                  top: 12,
+                  right: 12,
+                  child: Container(
+                    width: 32,
+                    height: 32,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: isSelected ? Colors.blue : Colors.white.withOpacity(0.5),
+                      border: Border.all(
+                        color: isSelected ? Colors.blue : Colors.white,
+                        width: 2,
+                      ),
+                    ),
+                    child: isSelected
+                        ? const Icon(
+                            Icons.check,
+                            color: Colors.white,
+                            size: 20,
+                          )
+                        : null,
+                  ),
+                ),
+              // Title at bottom
+              if (ZagreusDatabase.DISCOVER_SHOW_TITLES.read())
+                Positioned(
+                  bottom: 8,
+                  left: 8,
+                  right: 8,
+                  child: AutoSizeText(
+                    movie['title'] ?? 'Unknown',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: _titleFontSize,
+                      fontWeight: FontWeight.bold,
+                      shadows: const [
+                        Shadow(
+                          color: Colors.black,
+                          blurRadius: 4,
+                        ),
+                      ],
+                    ),
+                    maxLines: _titleMaxLines,
+                    minFontSize: 11,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _toggleSelection(int index) {
+    setState(() {
+      if (_selectedMovieIndices.contains(index)) {
+        _selectedMovieIndices.remove(index);
+      } else {
+        _selectedMovieIndices.add(index);
+      }
+    });
+  }
+
+  void _showRadarrConfig() {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setModalState) => Container(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Radarr Batch Add Settings',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 16),
+              ListTile(
+                leading: const Icon(Icons.hd),
+                title: const Text('Quality Profile'),
+                subtitle: Text(_radarrQualityProfileName ?? 'Not selected'),
+                onTap: () async {
+                  final radarrState = context.read<RadarrState>();
+                  final profiles = await radarrState.api!.qualityProfile.getAll();
+
+                  if (!mounted) return;
+
+                  showModalBottomSheet(
+                    context: context,
+                    builder: (context) => ListView.builder(
+                      itemCount: profiles.length,
+                      itemBuilder: (context, index) {
+                        final profile = profiles[index];
+                        return ListTile(
+                          title: Text(profile.name ?? 'Unknown'),
+                          onTap: () {
+                            setModalState(() {
+                              _radarrQualityProfileId = profile.id;
+                              _radarrQualityProfileName = profile.name;
+                            });
+                            ZagreusDatabase.Z_ASSISTANT_RADARR_QUALITY_PROFILE_ID.update(profile.id);
+                            ZagreusDatabase.Z_ASSISTANT_RADARR_QUALITY_PROFILE_NAME.update(profile.name);
+                            Navigator.pop(context);
+                          },
+                        );
+                      },
+                    ),
+                  );
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.folder),
+                title: const Text('Root Folder'),
+                subtitle: Text(_radarrRootFolder ?? 'Not selected'),
+                onTap: () async {
+                  final radarrState = context.read<RadarrState>();
+                  final folders = await radarrState.rootFolders;
+
+                  if (!mounted || folders == null) return;
+
+                  showModalBottomSheet(
+                    context: context,
+                    builder: (context) => ListView.builder(
+                      itemCount: folders.length,
+                      itemBuilder: (context, index) {
+                        final folder = folders[index];
+                        return ListTile(
+                          title: Text(folder.path ?? 'Unknown'),
+                          onTap: () {
+                            setModalState(() {
+                              _radarrRootFolder = folder.path;
+                            });
+                            ZagreusDatabase.Z_ASSISTANT_RADARR_ROOT_FOLDER.update(folder.path);
+                            Navigator.pop(context);
+                          },
+                        );
+                      },
+                    ),
+                  );
+                },
+              ),
+              SwitchListTile(
+                title: const Text('Search for Missing'),
+                value: _radarrSearchForMissing,
+                onChanged: (value) {
+                  setModalState(() {
+                    _radarrSearchForMissing = value;
+                  });
+                  ZagreusDatabase.Z_ASSISTANT_RADARR_SEARCH_FOR_MISSING.update(value);
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _addSelectedMoviesToRadarr() async {
+    if (_radarrQualityProfileId == null || _radarrRootFolder == null) {
+      showZagSnackBar(
+        title: 'Configuration Required',
+        message: 'Please select both Quality Profile and Root Folder',
+        type: ZagSnackbarType.ERROR,
+      );
+      return;
+    }
+
+    final radarrState = context.read<RadarrState>();
+    if (!radarrState.enabled || radarrState.api == null) {
+      showZagSnackBar(
+        title: 'Radarr Not Available',
+        message: 'Radarr is not enabled or configured',
+        type: ZagSnackbarType.ERROR,
+      );
+      return;
+    }
+
+    // Get profiles and folders
+    final profiles = await radarrState.qualityProfiles;
+    final folders = await radarrState.rootFolders;
+
+    if (profiles == null || folders == null) {
+      showZagSnackBar(
+        title: 'Configuration Error',
+        message: 'Could not fetch Radarr configuration',
+        type: ZagSnackbarType.ERROR,
+      );
+      return;
+    }
+
+    final selectedProfile = profiles.firstWhere(
+      (p) => p.id == _radarrQualityProfileId,
+      orElse: () => profiles.first,
+    );
+    final selectedFolder = folders.firstWhere(
+      (f) => f.path == _radarrRootFolder,
+      orElse: () => folders.first,
+    );
+
+    // Get selected movies
+    final selectedMovies = _selectedMovieIndices.map((i) => _movies[i]).toList();
+
+    showZagSnackBar(
+      title: 'Adding Movies',
+      message: 'Adding ${selectedMovies.length} movies to Radarr...',
+      type: ZagSnackbarType.INFO,
+    );
+
+    int successCount = 0;
+    int failCount = 0;
+
+    for (final movie in selectedMovies) {
+      try {
+        final tmdbId = movie['tmdbId'] as int?;
+        if (tmdbId == null) {
+          failCount++;
+          continue;
+        }
+
+        // Lookup movie on TMDB
+        final lookupResults = await radarrState.api!.movieLookup.get(
+          term: "tmdb:$tmdbId",
+        );
+
+        if (lookupResults.isEmpty) {
+          failCount++;
+          continue;
+        }
+
+        final radarrMovie = lookupResults.first;
+
+        // Check if already in library
+        if (radarrMovie.id != null && radarrMovie.id! > 0) {
+          failCount++;
+          continue;
+        }
+
+        // Add to Radarr
+        await radarrState.api!.movie.create(
+          movie: radarrMovie,
+          rootFolder: selectedFolder,
+          monitored: true,
+          minimumAvailability: RadarrAvailability.ANNOUNCED,
+          qualityProfile: selectedProfile,
+          searchForMovie: _radarrSearchForMissing,
+        );
+
+        successCount++;
+      } catch (e) {
+        failCount++;
+        ZagLogger().warning('Failed to add movie ${movie['title']}: $e');
+      }
+    }
+
+    showZagSnackBar(
+      title: 'Batch Add Complete',
+      message: 'Added $successCount movies. $failCount failed.',
+      type: successCount > 0 ? ZagSnackbarType.SUCCESS : ZagSnackbarType.ERROR,
+    );
+
+    // Exit multi-select mode
+    setState(() {
+      _isMultiSelectMode = false;
+      _selectedMovieIndices.clear();
+    });
+
+    // Refresh the list
+    _loadRecentlyReleasedMovies();
+  }
+
+  Widget _buildPosterImage(Map<String, dynamic> movie) {
+    final posterUrl = movie['poster'] as String?;
+
+    if (posterUrl == null || posterUrl.isEmpty) {
+      return _posterPlaceholder(movie);
+    }
+
+    return Image.network(
+      posterUrl,
+      fit: BoxFit.cover,
+      errorBuilder: (context, error, stackTrace) {
+        return _posterPlaceholder(movie);
+      },
+    );
+  }
+
+  Widget _posterPlaceholder(Map<String, dynamic> movie) {
+    return Container(
+      color: Colors.grey.shade800,
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.movie_rounded,
+              size: 40,
+              color: Colors.grey.shade600,
+            ),
+            SizedBox(height: 8),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8),
+              child: Text(
+                movie['title'] ?? 'Unknown',
+                style: TextStyle(
+                  color: Colors.grey.shade600,
+                  fontSize: 12,
+                ),
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleMovieTap({
+    required bool inLibrary,
+    required int? serviceItemId,
+    required int? tmdbId,
+    required String? title,
+  }) async {
+    if (inLibrary && serviceItemId != null) {
+      RadarrRoutes.MOVIE.go(
+        params: {
+          'movie': serviceItemId.toString(),
+        },
+      );
+      return;
+    }
+
+    if (tmdbId == null) {
+      showZagSnackBar(
+        title: title ?? 'Movie',
+        message: 'Missing TMDB identifier for this title.',
+        type: ZagSnackbarType.ERROR,
+      );
+      return;
+    }
+
+    final radarrState = context.read<RadarrState>();
+    if (!radarrState.enabled || radarrState.api == null) {
+      showZagSnackBar(
+        title: 'Radarr Unavailable',
+        message: 'Connect Radarr to add movies from Dashboard.',
+        type: ZagSnackbarType.INFO,
+      );
+      return;
+    }
+
+    bool loaderShown = false;
+    void dismissLoader() {
+      if (loaderShown && mounted) {
+        Navigator.of(context, rootNavigator: true).pop();
+        loaderShown = false;
+      }
+    }
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const Center(child: ZagLoader()),
+    );
+    loaderShown = true;
+
+    try {
+      final results = await radarrState.api!.movieLookup.get(
+        term: 'tmdb:$tmdbId',
+      );
+
+      if (!mounted) {
+        dismissLoader();
+        return;
+      }
+
+      dismissLoader();
+
+      if (results.isEmpty) {
+        showZagSnackBar(
+          title: title ?? 'Movie',
+          message: 'Could not find TMDB ID $tmdbId in Radarr.',
+          type: ZagSnackbarType.ERROR,
+        );
+        return;
+      }
+
+      final radarrMovie = results.first;
+
+      if (radarrMovie.id != null) {
+        RadarrRoutes.MOVIE.go(
+          params: {
+            'movie': radarrMovie.id!.toString(),
+          },
+        );
+        return;
+      }
+
+      RadarrRoutes.ADD_MOVIE_DETAILS.go(
+        extra: radarrMovie,
+        queryParams: {'isDiscovery': 'true'},
+      );
+    } catch (error, stack) {
+      dismissLoader();
+      if (!mounted) return;
+      ZagLogger().error('Failed to open Radarr add movie flow', error, stack);
+      showZagSnackBar(
+        title: title ?? 'Movie',
+        message: 'Something went wrong talking to Radarr.',
+        type: ZagSnackbarType.ERROR,
+      );
+    }
+  }
+}

--- a/zagreus/lib/modules/discover/widgets/discover_sections_editor.dart
+++ b/zagreus/lib/modules/discover/widgets/discover_sections_editor.dart
@@ -21,6 +21,7 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
     'missing',
     'downloading_soon',
     'popular_movies',
+    'recently_released_movies',
     'most_anticipated_movies',
     'popular_people',
     'deep_cuts',
@@ -47,6 +48,7 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
     'missing': 'Missing',
     'downloading_soon': 'Downloading Soon',
     'popular_movies': 'Popular Movies',
+    'recently_released_movies': 'Recently Released',
     'most_anticipated_movies': 'Most Anticipated Movies',
     'popular_people': 'Popular People',
     'deep_cuts': 'Deep Cuts',
@@ -826,6 +828,8 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
       case 'popular_movies':
       case 'popular_tv_shows':
         return Icons.star_rounded;
+      case 'recently_released_movies':
+        return Icons.new_releases_rounded;
       case 'popular_people':
         return Icons.person_rounded;
       case 'deep_cuts':


### PR DESCRIPTION
Adds a new "Recently Released" section to the Movies tab in the Discover dashboard, showing theatrical releases from the past 2 months.

Key changes:
- Add getRecentlyReleasedMovies() API method to TMDBApi with:
  - 2-month date range (from today backwards)
  - Theatrical releases only (release_type=4)
  - Minimum 10 vote count for quality filtering
  - Sorted by release date (newest first)
  - Region-aware (defaults to US)

- Create TMDBRecentlyReleasedMoviesRoute for full-page view:
  - Grid layout with poster tiles
  - Multi-select mode for batch adding to Radarr
  - Pagination support
  - Radarr library integration (shows library indicators)
  - Pull-to-refresh and infinite scroll

- Add section to Discover route:
  - Horizontal scrolling poster list
  - Integration with Radarr to show library status
  - Tap to add to Radarr or open existing movie
  - Long-press to refresh section

- Update Discover sections editor:
  - Add "Recently Released" to movie sections list
  - Add icon (new_releases_rounded)
  - Reorderable in section management UI

The implementation mirrors the existing "Popular Movies" section structure for consistency with the rest of the codebase.