### PR TITLE
Change TV icon to fire icon in discover

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -4938,7 +4938,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
         // Section title
         _sectionTitleRow(
           context: context,
-          leadingIcon: Icons.tv_rounded,
+          leadingIcon: Icons.local_fire_department_rounded,
           leadingIconColor: const Color(0xFF6688FF),
           moduleLabel: 'TMDB',
           moduleLabelColor: const Color(0xFF6688FF),


### PR DESCRIPTION
Changed the icon for TMDB Popular TV Shows from tv_rounded to local_fire_department_rounded to match the style of Popular Movies.