### PR TITLE
Fix Readarr API to use profile parameter for headers

### DIFF
--- a/zagreus/lib/modules/readarr/core/api/api.dart
+++ b/zagreus/lib/modules/readarr/core/api/api.dart
@@ -16,7 +16,7 @@ class ReadarrAPI {
         },
         contentType: Headers.jsonContentType,
         responseType: ResponseType.json,
-        headers: ZagProfile.current.readarrHeaders,
+        headers: profile.readarrHeaders,
         followRedirects: true,
         maxRedirects: 5,
       ),


### PR DESCRIPTION
The ReadarrAPI.from() factory method was incorrectly using ZagProfile.current.readarrHeaders instead of profile.readarrHeaders. This caused it to always use the currently active profile's headers instead of the profile being passed to the factory.

Now it correctly uses the profile parameter for headers, consistent with how it handles the host and API key.