### PR TITLE
Force SSID re-evaluation when saving connection details

### DIFF
--- a/zagreus/lib/modules/settings/routes/configuration_lidarr/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_lidarr/pages/connection_details.dart
@@ -124,7 +124,7 @@ class _State extends State<ConfigurationLidarrConnectionDetailsRoute>
         if (result.item1) {
           profile.lidarrLocalHost = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<LidarrState>().reset();
         }
       },
@@ -152,7 +152,7 @@ class _State extends State<ConfigurationLidarrConnectionDetailsRoute>
         if (result.item1) {
           profile.lidarrLocalSsids = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<LidarrState>().reset();
         }
       },

--- a/zagreus/lib/modules/settings/routes/configuration_nzbget/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_nzbget/pages/connection_details.dart
@@ -125,7 +125,7 @@ class _State extends State<ConfigurationNZBGetConnectionDetailsRoute>
         if (result.item1) {
           profile.nzbgetLocalHost = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<NZBGetState>().reset();
         }
       },
@@ -153,7 +153,7 @@ class _State extends State<ConfigurationNZBGetConnectionDetailsRoute>
         if (result.item1) {
           profile.nzbgetLocalSsids = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<NZBGetState>().reset();
         }
       },

--- a/zagreus/lib/modules/settings/routes/configuration_radarr/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_radarr/pages/connection_details.dart
@@ -130,7 +130,7 @@ class _State extends State<ConfigurationRadarrConnectionDetailsRoute>
         if (result.item1) {
           profile.radarrLocalHost = result.item2;
           profile.save();
-          ZagLocalConnectionService().refreshSsid();
+          ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<RadarrState>().resetProfile();
         }
       },
@@ -160,7 +160,7 @@ class _State extends State<ConfigurationRadarrConnectionDetailsRoute>
         if (result.item1) {
           profile.radarrLocalSsids = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<RadarrState>().resetProfile();
         }
       },

--- a/zagreus/lib/modules/settings/routes/configuration_readarr/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_readarr/pages/connection_details.dart
@@ -123,7 +123,7 @@ class _State extends State<ConfigurationReadarrConnectionDetailsRoute>
         if (result.item1) {
           profile.readarrLocalHost = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<ReadarrState>().reset();
         }
       },
@@ -151,7 +151,7 @@ class _State extends State<ConfigurationReadarrConnectionDetailsRoute>
         if (result.item1) {
           profile.readarrLocalSsids = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<ReadarrState>().reset();
         }
       },

--- a/zagreus/lib/modules/settings/routes/configuration_sabnzbd/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_sabnzbd/pages/connection_details.dart
@@ -124,7 +124,7 @@ class _State extends State<ConfigurationSABnzbdConnectionDetailsRoute>
         if (result.item1) {
           profile.sabnzbdLocalHost = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<SABnzbdState>().reset();
         }
       },
@@ -152,7 +152,7 @@ class _State extends State<ConfigurationSABnzbdConnectionDetailsRoute>
         if (result.item1) {
           profile.sabnzbdLocalSsids = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<SABnzbdState>().reset();
         }
       },

--- a/zagreus/lib/modules/settings/routes/configuration_sonarr/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_sonarr/pages/connection_details.dart
@@ -129,7 +129,7 @@ class _State extends State<ConfigurationSonarrConnectionDetailsRoute>
         if (result.item1) {
           profile.sonarrLocalHost = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<SonarrState>().reset();
         }
       },
@@ -159,7 +159,7 @@ class _State extends State<ConfigurationSonarrConnectionDetailsRoute>
         if (result.item1) {
           profile.sonarrLocalSsids = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<SonarrState>().reset();
         }
       },

--- a/zagreus/lib/modules/settings/routes/configuration_tautulli/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_tautulli/pages/connection_details.dart
@@ -124,7 +124,7 @@ class _State extends State<ConfigurationTautulliConnectionDetailsRoute>
         if (result.item1) {
           profile.tautulliLocalHost = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<TautulliState>().reset();
         }
       },
@@ -152,7 +152,7 @@ class _State extends State<ConfigurationTautulliConnectionDetailsRoute>
         if (result.item1) {
           profile.tautulliLocalSsids = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<TautulliState>().reset();
         }
       },

--- a/zagreus/lib/modules/settings/routes/configuration_unraid/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_unraid/pages/connection_details.dart
@@ -125,7 +125,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
         if (result.item1) {
           profile.unraidLocalHost = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<UnraidState>().reset();
         }
       },
@@ -153,7 +153,7 @@ class _State extends State<ConfigurationUnraidConnectionDetailsRoute>
         if (result.item1) {
           profile.unraidLocalSsids = result.item2;
           profile.save();
-          await ZagLocalConnectionService().refreshSsid();
+          await ZagLocalConnectionService().refreshSsid(forceEvaluate: true);
           context.read<UnraidState>().reset();
         }
       },


### PR DESCRIPTION
When users save local connection settings (local host or SSID list), the system now forces immediate re-evaluation of which connection to use, showing the "Network switched" toast right away instead of requiring users to exit and re-enter the configuration page.

This fixes the confusing UX where connection switching appeared delayed. Now the system immediately evaluates and switches after saving connection details, even if the current SSID hasn't changed.

Fixed for all modules:
- Radarr, Sonarr, Lidarr, Readarr
- SABnzbd, NZBGet
- Tautulli, Unraid