### PR TITLE
Revert "Rename Downloads to Queue in global drawer"

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
@@ -146,7 +146,7 @@ class _State extends State<DashboardRoute> {
                 // Free users: show download icon
                 return IconButton(
                   icon: const Icon(Icons.download_rounded),
-                  tooltip: 'Queue',
+                  tooltip: 'Downloads',
                   onPressed: () => _scaffoldKey.currentState?.openEndDrawer(),
                 );
               }

--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -1585,7 +1585,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
         actions.add(
           IconButton(
             icon: const Icon(Icons.download_rounded),
-            tooltip: 'Queue',
+            tooltip: 'Downloads',
             onPressed: () => _scaffoldKey.currentState?.openEndDrawer(),
           ),
         );

--- a/zagreus/lib/modules/overseerr/routes/overseerr/route.dart
+++ b/zagreus/lib/modules/overseerr/routes/overseerr/route.dart
@@ -120,7 +120,7 @@ class _State extends State<OverseerrRoute> {
     return [
       IconButton(
         icon: const Icon(Icons.download_rounded),
-        tooltip: 'Queue',
+        tooltip: 'Downloads',
         onPressed: _openDownloadsDrawer,
       ),
     ];

--- a/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_navigation/route.dart
@@ -114,7 +114,7 @@ class _State extends State<ConfigurationNavigationRoute>
     const db = ZagreusDatabase.DOWNLOADS_DRAWER_ENABLED;
     return db.listenableBuilder(
       builder: (context, _) => ZagBlock(
-        title: 'Queue Drawer',
+        title: 'Downloads Drawer',
         body: const [
           TextSpan(
             text: 'Access queues from the right edge.',

--- a/zagreus/lib/widgets/ui/downloads_drawer.dart
+++ b/zagreus/lib/widgets/ui/downloads_drawer.dart
@@ -94,7 +94,7 @@ class _ZagDownloadsDrawerState extends State<ZagDownloadsDrawer>
           const SizedBox(width: 12),
           Expanded(
             child: Text(
-              'Queue',
+              'Downloads',
               style: TextStyle(
                 fontSize: 20,
                 fontWeight: FontWeight.bold,


### PR DESCRIPTION
This reverts the previous commit, restoring all "Queue" references back to "Downloads":
- Main drawer title
- Settings page title (Queue Drawer → Downloads Drawer)
- Tooltips across all routes (overseerr, dashboard, discover)