### PR TITLE
Fix queue drawer not working on media apps

### DIFF
--- a/zagreus/lib/modules/lidarr/routes/lidarr.dart
+++ b/zagreus/lib/modules/lidarr/routes/lidarr.dart
@@ -62,6 +62,7 @@ class _State extends State<LidarrRoute> {
       module: ZagModule.LIDARR,
       body: _body(),
       drawer: _drawer(),
+      endDrawer: ZagGlobalCubeManager.instance.getEndDrawer(),
       appBar: _appBar() as PreferredSizeWidget?,
       bottomNavigationBar: _bottomNavigationBar(),
       onProfileChange: (_) {
@@ -120,6 +121,7 @@ class _State extends State<LidarrRoute> {
           icon: Icons.more_vert_rounded,
           onPressed: () async => _handlePopup(),
         ),
+        ..._buildQueueDrawerAction(),
       ];
     return ZagAppBar.dropdown(
       title: ZagModule.LIDARR.title,
@@ -129,6 +131,24 @@ class _State extends State<LidarrRoute> {
       pageController: _pageController,
       scrollControllers: LidarrNavigationBar.scrollControllers,
     );
+  }
+
+  List<Widget> _buildQueueDrawerAction() {
+    if (!ZagreusDatabase.DOWNLOADS_DRAWER_ENABLED.read()) return [];
+    return [
+      IconButton(
+        icon: const Icon(Icons.download_rounded),
+        tooltip: 'Queue',
+        onPressed: _openQueueDrawer,
+      ),
+    ];
+  }
+
+  void _openQueueDrawer() {
+    final scaffoldState = _scaffoldKey.currentState;
+    if (scaffoldState?.hasEndDrawer ?? false) {
+      scaffoldState?.openEndDrawer();
+    }
   }
 
   Future<void> _enterAddArtist() async {

--- a/zagreus/lib/modules/radarr/routes/radarr/route.dart
+++ b/zagreus/lib/modules/radarr/routes/radarr/route.dart
@@ -57,6 +57,7 @@ class _State extends State<RadarrRoute> {
       scaffoldKey: _scaffoldKey,
       module: ZagModule.RADARR,
       drawer: _drawer(),
+      endDrawer: ZagGlobalCubeManager.instance.getEndDrawer(),
       appBar: _appBar() as PreferredSizeWidget?,
       bottomNavigationBar: _bottomNavigationBar(),
       body: _body(),
@@ -100,6 +101,7 @@ class _State extends State<RadarrRoute> {
             tooltip: 'Multi-Select',
           ),
         const RadarrAppBarGlobalSettingsAction(),
+        ..._buildQueueDrawerAction(),
       ];
     }
     return ZagAppBar.dropdown(
@@ -110,6 +112,24 @@ class _State extends State<RadarrRoute> {
       pageController: _pageController,
       scrollControllers: RadarrNavigationBar.scrollControllers,
     );
+  }
+
+  List<Widget> _buildQueueDrawerAction() {
+    if (!ZagreusDatabase.DOWNLOADS_DRAWER_ENABLED.read()) return [];
+    return [
+      IconButton(
+        icon: const Icon(Icons.download_rounded),
+        tooltip: 'Queue',
+        onPressed: _openQueueDrawer,
+      ),
+    ];
+  }
+
+  void _openQueueDrawer() {
+    final scaffoldState = _scaffoldKey.currentState;
+    if (scaffoldState?.hasEndDrawer ?? false) {
+      scaffoldState?.openEndDrawer();
+    }
   }
 
   Widget _body() {

--- a/zagreus/lib/modules/sonarr/routes/sonarr/route.dart
+++ b/zagreus/lib/modules/sonarr/routes/sonarr/route.dart
@@ -51,6 +51,7 @@ class _State extends State<SonarrRoute> {
       scaffoldKey: _scaffoldKey,
       module: ZagModule.SONARR,
       drawer: _drawer(),
+      endDrawer: ZagGlobalCubeManager.instance.getEndDrawer(),
       appBar: _appBar(),
       bottomNavigationBar: _bottomNavigationBar(),
       body: _body(),
@@ -83,6 +84,7 @@ class _State extends State<SonarrRoute> {
       actions = [
         const SonarrAppBarAddSeriesAction(),
         const SonarrAppBarGlobalSettingsAction(),
+        ..._buildQueueDrawerAction(),
       ];
     }
     return ZagAppBar.dropdown(
@@ -93,6 +95,24 @@ class _State extends State<SonarrRoute> {
       pageController: _pageController,
       scrollControllers: SonarrNavigationBar.scrollControllers,
     );
+  }
+
+  List<Widget> _buildQueueDrawerAction() {
+    if (!ZagreusDatabase.DOWNLOADS_DRAWER_ENABLED.read()) return [];
+    return [
+      IconButton(
+        icon: const Icon(Icons.download_rounded),
+        tooltip: 'Queue',
+        onPressed: _openQueueDrawer,
+      ),
+    ];
+  }
+
+  void _openQueueDrawer() {
+    final scaffoldState = _scaffoldKey.currentState;
+    if (scaffoldState?.hasEndDrawer ?? false) {
+      scaffoldState?.openEndDrawer();
+    }
   }
 
   Widget _body() {


### PR DESCRIPTION
- Add endDrawer parameter to ZagScaffold using ZagGlobalCubeManager
- Add queue button (download icon) to app bar actions
- Implement _openQueueDrawer() method to open the end drawer
- Queue drawer only shows when DOWNLOADS_DRAWER_ENABLED setting is true
- Consistent implementation with Unraid and Overseerr modules