### PR TITLE
Open IMDb links in apps

### DIFF
--- a/zagreus/ios/Runner/Info.plist
+++ b/zagreus/ios/Runner/Info.plist
@@ -41,6 +41,7 @@
 	<array>
 		<string>plex</string>
 		<string>https</string>
+		<string>imdb</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/zagreus/lib/utils/links.dart
+++ b/zagreus/lib/utils/links.dart
@@ -21,8 +21,14 @@ enum ZagLinkedContent {
 
   static String? imdb(String? id) {
     if (id == null) return null;
-    const base = 'https://www.imdb.com';
 
+    // Use app deep link on mobile platforms to open the IMDb app
+    if (ZagPlatform.isMobile) {
+      return 'imdb:///title/$id/';
+    }
+
+    // Use web URL on desktop/web platforms
+    const base = 'https://www.imdb.com';
     return '$base/title/$id';
   }
 


### PR DESCRIPTION
Update IMDb links to use the imdb:/// URL scheme on mobile platforms, allowing links to open in the IMDb app instead of the browser. This matches the behavior of YouTube links which already open in the app.

Changes:
- Modified ZagLinkedContent.imdb() to use imdb:///title/{id}/ on iOS/Android
- Falls back to https://www.imdb.com/title/{id} on desktop/web platforms
- Added 'imdb' to LSApplicationQueriesSchemes in iOS Info.plist to allow the app to query if IMDb is installed