### PR TITLE
Open IMDb and Trakt links in native apps

### DIFF
--- a/zagreus/ios/Runner/Info.plist
+++ b/zagreus/ios/Runner/Info.plist
@@ -42,6 +42,7 @@
 		<string>plex</string>
 		<string>https</string>
 		<string>imdb</string>
+		<string>letterboxd</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
This allows the app to detect if the Letterboxd app is installed on iOS. Letterboxd links already use LaunchMode.externalNonBrowserApplication, which should automatically open links in the Letterboxd app via universal links when the app is installed, similar to how YouTube links work.