### PR TITLE
Add Rotten Tomatoes ratings to movie pages

### DIFF
--- a/zagreus/lib/api/omdb/omdb_api.dart
+++ b/zagreus/lib/api/omdb/omdb_api.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:zagreus/modules/discover/core/api_keys.dart';
+
+/// Model for Rotten Tomatoes ratings from OMDb API
+class RottenTomatoesRatings {
+  final String? tomatometer;
+  final String? audienceScore;
+  final int? tomatoMeterValue;
+  final int? audienceScoreValue;
+
+  RottenTomatoesRatings({
+    this.tomatometer,
+    this.audienceScore,
+    this.tomatoMeterValue,
+    this.audienceScoreValue,
+  });
+
+  factory RottenTomatoesRatings.fromJson(Map<String, dynamic> json) {
+    // Parse tomatometer from Ratings array
+    String? tomatometer;
+    int? tomatoMeterValue;
+    String? audienceScore;
+    int? audienceScoreValue;
+
+    final ratings = json['Ratings'] as List?;
+    if (ratings != null) {
+      for (final rating in ratings) {
+        if (rating['Source'] == 'Rotten Tomatoes') {
+          tomatometer = rating['Value'] as String?;
+          // Extract numeric value (e.g., "85%" -> 85)
+          if (tomatometer != null && tomatometer.isNotEmpty) {
+            tomatoMeterValue = int.tryParse(tomatometer.replaceAll('%', ''));
+          }
+        }
+      }
+    }
+
+    // Try to get audience score from the old tomato fields if available
+    // Note: OMDb may not always return these fields
+    final tomatoUserRating = json['tomatoUserRating'] as String?;
+    if (tomatoUserRating != null && tomatoUserRating != 'N/A') {
+      // tomatoUserRating is usually out of 5, convert to percentage
+      final rating = double.tryParse(tomatoUserRating);
+      if (rating != null) {
+        audienceScoreValue = ((rating / 5) * 100).round();
+        audienceScore = '$audienceScoreValue%';
+      }
+    }
+
+    return RottenTomatoesRatings(
+      tomatometer: tomatometer,
+      audienceScore: audienceScore,
+      tomatoMeterValue: tomatoMeterValue,
+      audienceScoreValue: audienceScoreValue,
+    );
+  }
+
+  bool get hasRatings =>
+      tomatoMeterValue != null || audienceScoreValue != null;
+}
+
+/// OMDb API client for fetching Rotten Tomatoes ratings
+class OMDbApi {
+  static const String _baseUrl = 'http://www.omdbapi.com';
+  static String get _apiKey => ApiKeys.omdbApiKey;
+
+  /// Fetch Rotten Tomatoes ratings for a movie by IMDb ID
+  static Future<RottenTomatoesRatings?> getRottenTomatoesRatings(
+      String? imdbId) async {
+    if (imdbId == null || imdbId.isEmpty) {
+      return null;
+    }
+
+    try {
+      // Use tomatoes=true to get RT ratings
+      final response = await http.get(
+        Uri.parse('$_baseUrl/?i=$imdbId&apikey=$_apiKey&tomatoes=true'),
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+
+        // Check if the API returned an error
+        if (data['Response'] == 'False') {
+          print('OMDb API Error: ${data['Error']}');
+          return null;
+        }
+
+        return RottenTomatoesRatings.fromJson(data);
+      }
+
+      print('OMDb API HTTP Error: ${response.statusCode}');
+      return null;
+    } catch (e) {
+      print('Error fetching Rotten Tomatoes ratings: $e');
+      return null;
+    }
+  }
+}

--- a/zagreus/lib/modules/radarr/routes/add_movie_details/route.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/route.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:zagreus/core.dart';
 import 'package:zagreus/modules/radarr.dart';
 import 'package:zagreus/modules/radarr/routes/movie_details/sheets/links.dart';
+import 'package:zagreus/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart';
 import 'package:zagreus/widgets/pages/invalid_route.dart';
 
 class AddMovieDetailsRoute extends StatefulWidget {
@@ -128,6 +129,9 @@ class _State extends State<AddMovieDetailsRoute>
             onTapShowOverview: true,
             exists: false,
             isExcluded: false,
+          ),
+          RadarrRottenTomatoesTile(
+            movie: context.read<RadarrAddMovieDetailsState>().movie,
           ),
           const RadarrAddMovieDetailsRootFolderTile(),
           const RadarrAddMovieDetailsMonitoredTile(),

--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets.dart
@@ -9,3 +9,4 @@ export 'widgets/page_cast_crew.dart';
 export 'widgets/page_files.dart';
 export 'widgets/page_history.dart';
 export 'widgets/page_overview.dart';
+export 'widgets/rotten_tomatoes_tile.dart';

--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/page_overview.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/page_overview.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/core.dart';
 import 'package:zagreus/modules/radarr.dart';
+import 'package:zagreus/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart';
 
 class RadarrMovieDetailsOverviewPage extends StatefulWidget {
   final RadarrMovie? movie;
@@ -37,6 +38,7 @@ class _State extends State<RadarrMovieDetailsOverviewPage>
           controller: RadarrMovieDetailsNavigationBar.scrollControllers[0],
           children: [
             RadarrMovieDetailsOverviewDescriptionTile(movie: widget.movie),
+            RadarrRottenTomatoesTile(movie: widget.movie),
             RadarrMovieDetailsOverviewInformationBlock(
               movie: widget.movie,
               qualityProfile: widget.qualityProfile,

--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:zagreus/api/omdb/omdb_api.dart';
+import 'package:zagreus/core.dart';
+import 'package:zagreus/modules/radarr.dart';
+
+class RadarrRottenTomatoesTile extends StatefulWidget {
+  final RadarrMovie? movie;
+
+  const RadarrRottenTomatoesTile({
+    Key? key,
+    required this.movie,
+  }) : super(key: key);
+
+  @override
+  State<RadarrRottenTomatoesTile> createState() =>
+      _RadarrRottenTomatoesTileState();
+}
+
+class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
+  RottenTomatoesRatings? _ratings;
+  bool _loading = true;
+  bool _hasError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchRatings();
+  }
+
+  Future<void> _fetchRatings() async {
+    if (widget.movie?.imdbId == null) {
+      setState(() {
+        _loading = false;
+        _hasError = true;
+      });
+      return;
+    }
+
+    try {
+      final ratings =
+          await OMDbApi.getRottenTomatoesRatings(widget.movie!.imdbId);
+      setState(() {
+        _ratings = ratings;
+        _loading = false;
+        _hasError = ratings == null || !ratings.hasRatings;
+      });
+    } catch (e) {
+      setState(() {
+        _loading = false;
+        _hasError = true;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Don't show anything if still loading or has error
+    if (_loading || _hasError || _ratings == null || !_ratings!.hasRatings) {
+      return const SizedBox.shrink();
+    }
+
+    return ZagTableCard(
+      content: [
+        if (_ratings!.tomatoMeterValue != null)
+          ZagTableContent(
+            title: '🍅 Tomatometer',
+            body: '${_ratings!.tomatoMeterValue}%',
+          ),
+        if (_ratings!.audienceScoreValue != null)
+          ZagTableContent(
+            title: '🍿 Audience Score',
+            body: '${_ratings!.audienceScoreValue}%',
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Integrate OMDb API to display Rotten Tomatoes Tomatometer and Audience Score on both the Add Movie and Movie Details pages. The ratings appear below the movie details block and above configuration options.

Changes:
- Created OMDb API client to fetch RT ratings using IMDb IDs
- Created RottenTomatoesRatings model to parse API responses
- Added RadarrRottenTomatoesTile widget to display ratings with 🍅 and 🍿 emojis
- Integrated RT tile into Add Movie page (above Root Folder)
- Integrated RT tile into Movie Details overview (above Monitoring)
- Widget automatically hides if ratings are unavailable

The OMDb API key is configured in api_keys.dart (gitignored for security).