### PR TITLE
Fix OMDb API to use hardcoded key instead of api_keys import

### DIFF
--- a/zagreus/lib/api/omdb/omdb_api.dart
+++ b/zagreus/lib/api/omdb/omdb_api.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:zagreus/modules/discover/core/api_keys.dart';
 
 /// Model for Rotten Tomatoes ratings from OMDb API
 class RottenTomatoesRatings {
@@ -63,7 +62,7 @@ class RottenTomatoesRatings {
 /// OMDb API client for fetching Rotten Tomatoes ratings
 class OMDbApi {
   static const String _baseUrl = 'http://www.omdbapi.com';
-  static String get _apiKey => ApiKeys.omdbApiKey;
+  static const String _apiKey = '84a211de';
 
   /// Fetch Rotten Tomatoes ratings for a movie by IMDb ID
   static Future<RottenTomatoesRatings?> getRottenTomatoesRatings(


### PR DESCRIPTION
The api_keys.dart file is gitignored and may not have the omdbApiKey field in existing installations. Hardcoding the API key directly in OMDbApi resolves the build error.