### PR TITLE
Redesign ratings display with IMDb, RT, and Metacritic

### DIFF
--- a/zagreus/lib/api/omdb/omdb_api.dart
+++ b/zagreus/lib/api/omdb/omdb_api.dart
@@ -1,62 +1,56 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
-/// Model for Rotten Tomatoes ratings from OMDb API
-class RottenTomatoesRatings {
-  final String? tomatometer;
-  final String? audienceScore;
-  final int? tomatoMeterValue;
-  final int? audienceScoreValue;
+/// Model for movie ratings from OMDb API
+class MovieRatings {
+  final String? imdbRating;
+  final String? imdbVotes;
+  final String? rottenTomatoes;
+  final String? metacritic;
 
-  RottenTomatoesRatings({
-    this.tomatometer,
-    this.audienceScore,
-    this.tomatoMeterValue,
-    this.audienceScoreValue,
+  MovieRatings({
+    this.imdbRating,
+    this.imdbVotes,
+    this.rottenTomatoes,
+    this.metacritic,
   });
 
-  factory RottenTomatoesRatings.fromJson(Map<String, dynamic> json) {
-    // Parse tomatometer from Ratings array
-    String? tomatometer;
-    int? tomatoMeterValue;
-    String? audienceScore;
-    int? audienceScoreValue;
+  factory MovieRatings.fromJson(Map<String, dynamic> json) {
+    // Parse ratings from Ratings array
+    String? rottenTomatoes;
+    String? metacritic;
 
     final ratings = json['Ratings'] as List?;
     if (ratings != null) {
       for (final rating in ratings) {
-        if (rating['Source'] == 'Rotten Tomatoes') {
-          tomatometer = rating['Value'] as String?;
-          // Extract numeric value (e.g., "85%" -> 85)
-          if (tomatometer != null && tomatometer.isNotEmpty) {
-            tomatoMeterValue = int.tryParse(tomatometer.replaceAll('%', ''));
+        final source = rating['Source'] as String?;
+        final value = rating['Value'] as String?;
+
+        if (source == 'Rotten Tomatoes') {
+          rottenTomatoes = value;
+        } else if (source == 'Metacritic') {
+          // Metacritic comes as "96/100", extract just the number
+          if (value != null && value.contains('/')) {
+            metacritic = value.split('/').first;
           }
         }
       }
     }
 
-    // Try to get audience score from the old tomato fields if available
-    // Note: OMDb may not always return these fields
-    final tomatoUserRating = json['tomatoUserRating'] as String?;
-    if (tomatoUserRating != null && tomatoUserRating != 'N/A') {
-      // tomatoUserRating is usually out of 5, convert to percentage
-      final rating = double.tryParse(tomatoUserRating);
-      if (rating != null) {
-        audienceScoreValue = ((rating / 5) * 100).round();
-        audienceScore = '$audienceScoreValue%';
-      }
-    }
+    // Get IMDb rating
+    final imdbRating = json['imdbRating'] as String?;
+    final imdbVotes = json['imdbVotes'] as String?;
 
-    return RottenTomatoesRatings(
-      tomatometer: tomatometer,
-      audienceScore: audienceScore,
-      tomatoMeterValue: tomatoMeterValue,
-      audienceScoreValue: audienceScoreValue,
+    return MovieRatings(
+      imdbRating: (imdbRating != null && imdbRating != 'N/A') ? imdbRating : null,
+      imdbVotes: (imdbVotes != null && imdbVotes != 'N/A') ? imdbVotes : null,
+      rottenTomatoes: (rottenTomatoes != null && rottenTomatoes != 'N/A') ? rottenTomatoes : null,
+      metacritic: (metacritic != null && metacritic != 'N/A') ? metacritic : null,
     );
   }
 
   bool get hasRatings =>
-      tomatoMeterValue != null || audienceScoreValue != null;
+      imdbRating != null || rottenTomatoes != null || metacritic != null;
 }
 
 /// OMDb API client for fetching Rotten Tomatoes ratings
@@ -64,17 +58,15 @@ class OMDbApi {
   static const String _baseUrl = 'http://www.omdbapi.com';
   static const String _apiKey = '84a211de';
 
-  /// Fetch Rotten Tomatoes ratings for a movie by IMDb ID
-  static Future<RottenTomatoesRatings?> getRottenTomatoesRatings(
-      String? imdbId) async {
+  /// Fetch movie ratings (IMDb, Rotten Tomatoes, Metacritic) by IMDb ID
+  static Future<MovieRatings?> getMovieRatings(String? imdbId) async {
     if (imdbId == null || imdbId.isEmpty) {
       return null;
     }
 
     try {
-      // Use tomatoes=true to get RT ratings
       final response = await http.get(
-        Uri.parse('$_baseUrl/?i=$imdbId&apikey=$_apiKey&tomatoes=true'),
+        Uri.parse('$_baseUrl/?i=$imdbId&apikey=$_apiKey'),
       );
 
       if (response.statusCode == 200) {
@@ -86,13 +78,13 @@ class OMDbApi {
           return null;
         }
 
-        return RottenTomatoesRatings.fromJson(data);
+        return MovieRatings.fromJson(data);
       }
 
       print('OMDb API HTTP Error: ${response.statusCode}');
       return null;
     } catch (e) {
-      print('Error fetching Rotten Tomatoes ratings: $e');
+      print('Error fetching movie ratings: $e');
       return null;
     }
   }

--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/api/omdb/omdb_api.dart';
-import 'package:zagreus/core.dart';
 import 'package:zagreus/modules/radarr.dart';
 
 class RadarrRottenTomatoesTile extends StatefulWidget {
@@ -17,7 +16,7 @@ class RadarrRottenTomatoesTile extends StatefulWidget {
 }
 
 class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
-  RottenTomatoesRatings? _ratings;
+  MovieRatings? _ratings;
   bool _loading = true;
   bool _hasError = false;
 
@@ -37,8 +36,7 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
     }
 
     try {
-      final ratings =
-          await OMDbApi.getRottenTomatoesRatings(widget.movie!.imdbId);
+      final ratings = await OMDbApi.getMovieRatings(widget.movie!.imdbId);
       setState(() {
         _ratings = ratings;
         _loading = false;
@@ -59,19 +57,41 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
       return const SizedBox.shrink();
     }
 
-    return ZagTableCard(
-      content: [
-        if (_ratings!.tomatoMeterValue != null)
-          ZagTableContent(
-            title: '🍅 Tomatometer',
-            body: '${_ratings!.tomatoMeterValue}%',
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          if (_ratings!.imdbRating != null)
+            _buildRating('⭐', _ratings!.imdbRating!),
+          if (_ratings!.rottenTomatoes != null)
+            _buildRating('🍅', _ratings!.rottenTomatoes!),
+          if (_ratings!.metacritic != null)
+            _buildRating('Ⓜ️', _ratings!.metacritic!),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRating(String emoji, String value) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 16.0),
+      child: Row(
+        children: [
+          Text(
+            emoji,
+            style: const TextStyle(fontSize: 18),
           ),
-        if (_ratings!.audienceScoreValue != null)
-          ZagTableContent(
-            title: '🍿 Audience Score',
-            body: '${_ratings!.audienceScoreValue}%',
+          const SizedBox(width: 6),
+          Text(
+            value,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
           ),
-      ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
Updated the ratings widget to show a clean, horizontal layout with all three major rating sources instead of just Rotten Tomatoes.

Changes:
- Renamed RottenTomatoesRatings to MovieRatings
- Added IMDb rating (⭐), Metacritic score (Ⓜ️) alongside RT (🍅)
- Removed ZagTableCard border/container for cleaner look
- Display ratings as simple emoji + value pairs in a row
- Parse all ratings from OMDb API Ratings array plus imdbRating field
- Metacritic shows just the number (extracted from "96/100" format)

Example display: ⭐ 8.1 🍅 95% Ⓜ️ 96