### PR TITLE
Fix VoidCallback return type error in Metacritic links

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -92,7 +92,7 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
                 final query = year != null
                     ? '$searchTitle $year'
                     : searchTitle;
-                return 'https://www.metacritic.com/search/$query/'.openLink();
+                'https://www.metacritic.com/search/$query/'.openLink();
               },
             ),
         ],

--- a/zagreus/lib/modules/sonarr/routes/series_details/widgets/ratings_tile.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/widgets/ratings_tile.dart
@@ -91,7 +91,7 @@ class _SonarrRatingsTileState extends State<SonarrRatingsTile> {
                 final query = year != null
                     ? '$searchTitle $year'
                     : searchTitle;
-                return 'https://www.metacritic.com/search/$query/'.openLink();
+                'https://www.metacritic.com/search/$query/'.openLink();
               },
             ),
         ],


### PR DESCRIPTION
Removed 'return' statement from Metacritic callback since VoidCallback expects void return type, not a value.