### PR TITLE
Make only IMDb rating clickable, improve deep linking

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/api/omdb/omdb_api.dart';
-import 'package:zagreus/extensions/string/links.dart';
 import 'package:zagreus/modules/radarr.dart';
+import 'package:zagreus/system/platform.dart';
+import 'package:zagreus/utils/links.dart';
 
 class RadarrRottenTomatoesTile extends StatefulWidget {
   final RadarrMovie? movie;
@@ -59,11 +60,6 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
     }
 
     final imdbId = widget.movie?.imdbId;
-    final title = widget.movie?.title;
-    final year = widget.movie?.year;
-
-    // Construct search-friendly title (encode for URL)
-    final searchTitle = title != null ? Uri.encodeComponent(title) : null;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
@@ -74,54 +70,46 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
             _buildRating(
               '⭐',
               _ratings!.imdbRating!,
-              () => 'https://www.imdb.com/title/$imdbId'.openLink(),
-            ),
-          if (_ratings!.rottenTomatoes != null && searchTitle != null)
-            _buildRating(
-              '🍅',
-              _ratings!.rottenTomatoes!,
-              () => 'https://www.rottentomatoes.com/search?search=$searchTitle'
-                  .openLink(),
-            ),
-          if (_ratings!.metacritic != null && searchTitle != null)
-            _buildRating(
-              'Ⓜ️',
-              _ratings!.metacritic!,
-              () {
-                // Add year to search if available for better results
-                final query = year != null
-                    ? '$searchTitle $year'
-                    : searchTitle;
-                'https://www.metacritic.com/search/$query/'.openLink();
+              onTap: () {
+                // Use imdb:// deep link on mobile, https on web
+                final link = ZagPlatform.isMobile
+                    ? ZagLinkedContent.imdb(imdbId)
+                    : 'https://www.imdb.com/title/$imdbId';
+                if (link != null) link.openLink();
               },
             ),
+          if (_ratings!.rottenTomatoes != null)
+            _buildRating('🍅', _ratings!.rottenTomatoes!),
+          if (_ratings!.metacritic != null)
+            _buildRating('Ⓜ️', _ratings!.metacritic!),
         ],
       ),
     );
   }
 
-  Widget _buildRating(String emoji, String value, VoidCallback onTap) {
+  Widget _buildRating(String emoji, String value, {VoidCallback? onTap}) {
+    final content = Row(
+      children: [
+        Text(
+          emoji,
+          style: const TextStyle(fontSize: 18),
+        ),
+        const SizedBox(width: 6),
+        Text(
+          value,
+          style: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+
     return Padding(
       padding: const EdgeInsets.only(right: 16.0),
-      child: GestureDetector(
-        onTap: onTap,
-        child: Row(
-          children: [
-            Text(
-              emoji,
-              style: const TextStyle(fontSize: 18),
-            ),
-            const SizedBox(width: 6),
-            Text(
-              value,
-              style: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ],
-        ),
-      ),
+      child: onTap != null
+          ? GestureDetector(onTap: onTap, child: content)
+          : content,
     );
   }
 }

--- a/zagreus/lib/modules/sonarr/routes/series_details/widgets/ratings_tile.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/widgets/ratings_tile.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/api/omdb/omdb_api.dart';
-import 'package:zagreus/extensions/string/links.dart';
 import 'package:zagreus/modules/sonarr.dart';
+import 'package:zagreus/system/platform.dart';
+import 'package:zagreus/utils/links.dart';
 
 class SonarrRatingsTile extends StatefulWidget {
   final SonarrSeries? series;
@@ -37,12 +38,20 @@ class _SonarrRatingsTileState extends State<SonarrRatingsTile> {
 
     try {
       final ratings = await OMDbApi.getMovieRatings(widget.series!.imdbId);
+
+      // Debug: Log ratings data for TV shows
+      print('OMDb Ratings for ${widget.series!.title} (${widget.series!.imdbId}):');
+      print('  IMDb: ${ratings?.imdbRating}');
+      print('  RT: ${ratings?.rottenTomatoes}');
+      print('  Metacritic: ${ratings?.metacritic}');
+
       setState(() {
         _ratings = ratings;
         _loading = false;
         _hasError = ratings == null || !ratings.hasRatings;
       });
     } catch (e) {
+      print('Error fetching ratings for ${widget.series!.title}: $e');
       setState(() {
         _loading = false;
         _hasError = true;
@@ -58,11 +67,6 @@ class _SonarrRatingsTileState extends State<SonarrRatingsTile> {
     }
 
     final imdbId = widget.series?.imdbId;
-    final title = widget.series?.title;
-    final year = widget.series?.year;
-
-    // Construct search-friendly title (encode for URL)
-    final searchTitle = title != null ? Uri.encodeComponent(title) : null;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
@@ -73,54 +77,46 @@ class _SonarrRatingsTileState extends State<SonarrRatingsTile> {
             _buildRating(
               '⭐',
               _ratings!.imdbRating!,
-              () => 'https://www.imdb.com/title/$imdbId'.openLink(),
-            ),
-          if (_ratings!.rottenTomatoes != null && searchTitle != null)
-            _buildRating(
-              '🍅',
-              _ratings!.rottenTomatoes!,
-              () => 'https://www.rottentomatoes.com/search?search=$searchTitle'
-                  .openLink(),
-            ),
-          if (_ratings!.metacritic != null && searchTitle != null)
-            _buildRating(
-              'Ⓜ️',
-              _ratings!.metacritic!,
-              () {
-                // Add year to search if available for better results
-                final query = year != null
-                    ? '$searchTitle $year'
-                    : searchTitle;
-                'https://www.metacritic.com/search/$query/'.openLink();
+              onTap: () {
+                // Use imdb:// deep link on mobile, https on web
+                final link = ZagPlatform.isMobile
+                    ? ZagLinkedContent.imdb(imdbId)
+                    : 'https://www.imdb.com/title/$imdbId';
+                if (link != null) link.openLink();
               },
             ),
+          if (_ratings!.rottenTomatoes != null)
+            _buildRating('🍅', _ratings!.rottenTomatoes!),
+          if (_ratings!.metacritic != null)
+            _buildRating('Ⓜ️', _ratings!.metacritic!),
         ],
       ),
     );
   }
 
-  Widget _buildRating(String emoji, String value, VoidCallback onTap) {
+  Widget _buildRating(String emoji, String value, {VoidCallback? onTap}) {
+    final content = Row(
+      children: [
+        Text(
+          emoji,
+          style: const TextStyle(fontSize: 18),
+        ),
+        const SizedBox(width: 6),
+        Text(
+          value,
+          style: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+
     return Padding(
       padding: const EdgeInsets.only(right: 16.0),
-      child: GestureDetector(
-        onTap: onTap,
-        child: Row(
-          children: [
-            Text(
-              emoji,
-              style: const TextStyle(fontSize: 18),
-            ),
-            const SizedBox(width: 6),
-            Text(
-              value,
-              style: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ],
-        ),
-      ),
+      child: onTap != null
+          ? GestureDetector(onTap: onTap, child: content)
+          : content,
     );
   }
 }


### PR DESCRIPTION
Changes:
- IMDb rating now uses direct imdb:/// deep link on mobile for better app opening
- Removed clickability from RT and Metacritic (too many ads)
- RT and Metacritic now display as static ratings
- Made onTap callback optional in _buildRating method
- Added debug logging to investigate TV show ratings issues

The star emoji and rating are still clickable for IMDb to open the app. RT and Metacritic are now just informational display.