### PR TITLE
Add Up Next section for shows feature

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -46,6 +46,7 @@ import 'package:zagreus/utils/zagreus_pro.dart';
 import 'package:zagreus/utils/zagreus_mega.dart';
 import 'package:zagreus/utils/zagreus_ultra.dart';
 import 'package:zagreus/services/deep_cuts_service.dart';
+import 'package:zagreus/services/up_next_service.dart';
 import 'package:zagreus/modules/overseerr/core/extensions.dart';
 import 'package:zagreus/modules/overseerr/core/state.dart';
 import 'package:zagreus/modules/tautulli/core/state.dart';
@@ -112,6 +113,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       'most_anticipated_movies_section';
   static const _scrollIdPopularPeople = 'popular_people_section';
   static const _scrollIdDeepCuts = 'deep_cuts_recommendations';
+  static const _scrollIdUpNext = 'up_next_recommendations';
 
   static const _recentlyDownloadedListKey =
       PageStorageKey<String>('discover_recently_downloaded_movies');
@@ -137,6 +139,8 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       PageStorageKey<String>('discover_popular_people');
   static const _deepCutsListKey =
       PageStorageKey<String>('discover_deep_cuts');
+  static const _upNextListKey =
+      PageStorageKey<String>('discover_up_next');
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   final GlobalKey<ZChatPageState> _agentChatKey = GlobalKey<ZChatPageState>();
   late ZagPageController _pageController;
@@ -228,6 +232,10 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   Future<DeepCutsResult>? _deepCutsFuture;
   bool _deepCutsSyncInitialized = false;
 
+  // Up Next future (cached to avoid refetching on rebuild)
+  Future<UpNextResult>? _upNextFuture;
+  bool _upNextSyncInitialized = false;
+
   @override
   void initState() {
     super.initState();
@@ -253,6 +261,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     _loadMockTrendingData();
     _startAutoScroll();
     _syncDeepCutsIfNeeded();
+    _syncUpNextIfNeeded();
   }
 
   void _refreshQuickSetupModal() {
@@ -295,6 +304,31 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       }
     } catch (e, stack) {
       ZagLogger().error('Deep Cuts sync check failed', e, stack);
+    }
+  }
+
+  Future<void> _syncUpNextIfNeeded() async {
+    // Guard to ensure this only runs once
+    if (_upNextSyncInitialized || !ZagreusMega.isEnabled) return;
+    _upNextSyncInitialized = true;
+
+    try {
+      final upNextService = UpNextService();
+      // Fetch current state once
+      final fetchResult = await upNextService.fetchRecommendations();
+
+      // Check if regeneration is needed based on fetched data
+      final needsRegen = upNextService.needsRegeneration(
+        existingResult: fetchResult,
+      );
+
+      if (needsRegen) {
+        ZagLogger().debug('Up Next need regeneration - triggering...');
+        // Fire and forget - don't await
+        upNextService.generateRecommendations();
+      }
+    } catch (e, stack) {
+      ZagLogger().error('Up Next sync check failed', e, stack);
     }
   }
 
@@ -1900,6 +1934,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       'popular_tv_shows',
       'trending_new_tv_shows',
       'most_anticipated',
+      'up_next',
     ];
 
     // Get saved order or use default
@@ -1922,6 +1957,12 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
             if (_showTitles) const SizedBox(height: 12)
           ]),
       'most_anticipated': () => _mostAnticipatedShowsSection(),
+      'up_next': () => ZagreusMega.isEnabled
+          ? Column(children: [
+              _upNextSection(),
+              if (_showTitles) const SizedBox(height: 4)
+            ])
+          : const SizedBox.shrink(),
     };
 
     // Build sections in saved order
@@ -6686,6 +6727,319 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
               // Reason
               Text(
                 movie.reason,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: (Theme.of(context).brightness == Brightness.dark
+                          ? Colors.white
+                          : Colors.black)
+                      .withOpacity(0.7),
+                ),
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _upNextSection() {
+    final upNextService = UpNextService();
+
+    // Initialize future once if not already set
+    _upNextFuture ??= upNextService.fetchRecommendations();
+
+    return FutureBuilder<UpNextResult>(
+      future: _upNextFuture,
+      builder: (context, futureSnapshot) {
+        // Only show refresh button if:
+        // 1. We have no data yet (empty state) OR
+        // 2. We have data but it's time for regeneration (nextGenerationAt has passed)
+        // Do NOT show if we have a successful list that's still fresh
+        final canRefresh = !futureSnapshot.hasData ||
+            !futureSnapshot.data!.success ||
+            (futureSnapshot.data!.nextGenerationAt != null &&
+                DateTime.now().isAfter(futureSnapshot.data!.nextGenerationAt!));
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Section title with sync button
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.auto_awesome_rounded,
+                    color: ZagColours.purple,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    'Z',
+                    style: TextStyle(
+                      fontSize: _moduleSectionTitleFontSize,
+                      fontWeight: FontWeight.bold,
+                      color: ZagColours.purple,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Text(
+                      'Up Next',
+                      style: TextStyle(
+                        fontSize: _moduleSectionTitleFontSize,
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).brightness == Brightness.dark
+                            ? Colors.white
+                            : Colors.black87,
+                      ),
+                    ),
+                  ),
+                  // Refresh button (hidden if cooldown active)
+                  if (canRefresh)
+                    IconButton(
+                      icon: Icon(
+                        Icons.refresh_rounded,
+                        color: ZagColours.purple,
+                        size: 20,
+                      ),
+                      onPressed: () async {
+                        await upNextService.generateRecommendations(
+                            force: true);
+                        if (mounted) {
+                          setState(() {
+                            _upNextFuture =
+                                upNextService.fetchRecommendations();
+                          });
+                        }
+                      },
+                    ),
+                ],
+              ),
+            ),
+            // Content
+            Builder(
+              builder: (context) {
+                if (futureSnapshot.connectionState == ConnectionState.waiting) {
+                  return Container(
+                    height: 280,
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: const Center(child: CircularProgressIndicator()),
+                  );
+                }
+
+                if (!futureSnapshot.hasData ||
+                    !futureSnapshot.data!.success ||
+                    futureSnapshot.data!.recommendations == null ||
+                    futureSnapshot.data!.recommendations!.isEmpty) {
+                  return _upNextEmptyState(futureSnapshot.data);
+                }
+
+                final recommendations = futureSnapshot.data!.recommendations!;
+
+                return Container(
+                  height: 300,
+                  padding: const EdgeInsets.only(left: 16),
+                  child: ListView.builder(
+                    key: _upNextListKey,
+                    controller:
+                        _sectionScrollController(_scrollIdUpNext),
+                    scrollDirection: Axis.horizontal,
+                    itemCount: recommendations.length,
+                    itemBuilder: (context, index) {
+                      return _upNextShowCard(recommendations[index]);
+                    },
+                  ),
+                );
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _upNextEmptyState(UpNextResult? result) {
+    // Determine message based on error type
+    String title = 'No recommendations yet';
+    String message = 'Tap refresh to generate AI-powered show recommendations';
+    IconData icon = Icons.live_tv_rounded;
+
+    if (result != null && !result.success && result.error != null) {
+      switch (result.error!) {
+        case UpNextError.notSynced:
+          title = 'Library not synced';
+          message = result.errorMessage ?? 'Please sync your library first';
+          icon = Icons.sync_problem_rounded;
+          break;
+        case UpNextError.noMegaOrUltra:
+          title = 'Mega subscription required';
+          message = result.errorMessage ?? 'Up Next requires Mega or Ultra';
+          icon = Icons.lock_rounded;
+          break;
+        case UpNextError.alreadyGenerating:
+          title = 'Generation in progress';
+          message = result.errorMessage ??
+              'Please wait while recommendations are being generated';
+          icon = Icons.hourglass_empty_rounded;
+          break;
+        case UpNextError.fetchFailed:
+        case UpNextError.unknown:
+          title = 'Something went wrong';
+          message = result.errorMessage ?? 'Please try again later';
+          icon = Icons.error_outline_rounded;
+          break;
+      }
+    }
+
+    return Container(
+      height: 280,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 48,
+              color: (Theme.of(context).brightness == Brightness.dark
+                      ? Colors.white
+                      : Colors.black)
+                  .withOpacity(0.3),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              style: TextStyle(
+                color: (Theme.of(context).brightness == Brightness.dark
+                        ? Colors.white
+                        : Colors.black)
+                    .withOpacity(0.7),
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Text(
+                message,
+                style: TextStyle(
+                  color: (Theme.of(context).brightness == Brightness.dark
+                          ? Colors.white
+                          : Colors.black)
+                      .withOpacity(0.5),
+                  fontSize: 14,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _upNextShowCard(UpNextShow show) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 16),
+      child: GestureDetector(
+        onTap: () async {
+          // Use tmdbId from backend if available
+          if (show.tmdbId != null) {
+            await _openTVShowInSonarr(tmdbId: show.tmdbId!, title: show.title);
+          } else {
+            // Fallback: search for the show if no tmdbId
+            final tmdbApi = TMDBApi();
+            final searchResults =
+                await tmdbApi.searchMulti('${show.title} ${show.year}');
+
+            // Filter for TV shows only
+            final tvResults =
+                searchResults.where((r) => r['media_type'] == 'tv').toList();
+
+            if (tvResults.isNotEmpty) {
+              final tmdbId = tvResults.first['id'] as int;
+              await _openTVShowInSonarr(tmdbId: tmdbId, title: show.title);
+            }
+          }
+        },
+        child: Container(
+          width: 160,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Show poster
+              Container(
+                height: 240,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  color: ZagColours.purple.withOpacity(0.2),
+                  border: show.posterUrl == null
+                      ? Border.all(
+                          color: ZagColours.purple.withOpacity(0.3),
+                          width: 2,
+                        )
+                      : null,
+                  image: show.posterUrl != null
+                      ? DecorationImage(
+                          image: NetworkImage(show.posterUrl!),
+                          fit: BoxFit.cover,
+                        )
+                      : null,
+                ),
+                child: show.posterUrl == null
+                    ? Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.live_tv_rounded,
+                              size: 48,
+                              color: ZagColours.purple.withOpacity(0.5),
+                            ),
+                            const SizedBox(height: 12),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 12),
+                              child: Text(
+                                show.title,
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.bold,
+                                  color: Theme.of(context).brightness ==
+                                          Brightness.dark
+                                      ? Colors.white
+                                      : Colors.black87,
+                                ),
+                                textAlign: TextAlign.center,
+                                maxLines: 3,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              '${show.year}',
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: (Theme.of(context).brightness ==
+                                            Brightness.dark
+                                        ? Colors.white
+                                        : Colors.black)
+                                    .withOpacity(0.6),
+                              ),
+                            ),
+                          ],
+                        ),
+                      )
+                    : null,
+              ),
+              const SizedBox(height: 8),
+              // Reason
+              Text(
+                show.reason,
                 style: TextStyle(
                   fontSize: 12,
                   color: (Theme.of(context).brightness == Brightness.dark

--- a/zagreus/lib/modules/discover/widgets/discover_sections_editor.dart
+++ b/zagreus/lib/modules/discover/widgets/discover_sections_editor.dart
@@ -33,6 +33,7 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
     'popular_tv_shows',
     'trending_new_tv_shows',
     'most_anticipated',
+    'up_next',
   ];
 
   static const double _posterHeightMin = 150.0;
@@ -57,6 +58,7 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
     'popular_tv_shows': 'Popular TV Shows',
     'trending_new_tv_shows': 'Trending New',
     'most_anticipated': 'Most Anticipated',
+    'up_next': 'Up Next',
   };
 
   late List<String> _movieSections;
@@ -840,6 +842,8 @@ class DiscoverSectionsEditorState extends State<DiscoverSectionsEditor> {
         return Icons.favorite_rounded;
       case 'most_anticipated_movies':
         return Icons.favorite_rounded;
+      case 'up_next':
+        return Icons.auto_awesome_rounded;
       default:
         return Icons.view_list_rounded;
     }

--- a/zagreus/lib/services/up_next_service.dart
+++ b/zagreus/lib/services/up_next_service.dart
@@ -1,0 +1,310 @@
+import 'package:zagreus/core.dart';
+import 'package:zagreus/services/device_id_service.dart';
+import 'package:zagreus/services/hmac_encryption_service.dart';
+import 'package:zagreus/utils/zagreus_ultra.dart';
+import 'package:zagreus/utils/zagreus_mega.dart';
+import 'package:zagreus/supabase/core.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+enum UpNextError {
+  noMegaOrUltra,
+  alreadyGenerating,
+  fetchFailed,
+  notSynced,
+  unknown,
+}
+
+class UpNextResult {
+  final bool success;
+  final UpNextError? error;
+  final String? errorMessage;
+  final List<UpNextShow>? recommendations;
+  final DateTime? generatedAt;
+  final DateTime? nextGenerationAt;
+
+  UpNextResult.success({
+    required this.recommendations,
+    this.generatedAt,
+    this.nextGenerationAt,
+  })  : success = true,
+        error = null,
+        errorMessage = null;
+
+  UpNextResult.failure(this.error, [this.errorMessage])
+      : success = false,
+        recommendations = null,
+        generatedAt = null,
+        nextGenerationAt = null;
+}
+
+class UpNextShow {
+  final String title;
+  final int year;
+  final List<String> genres;
+  final String reason;
+  final int popularityScore;
+  final int? tmdbId;
+  final String? posterPath;
+  final int? seasons;
+
+  UpNextShow({
+    required this.title,
+    required this.year,
+    required this.genres,
+    required this.reason,
+    required this.popularityScore,
+    this.tmdbId,
+    this.posterPath,
+    this.seasons,
+  });
+
+  String? get posterUrl {
+    if (posterPath == null || posterPath!.isEmpty) return null;
+    return 'https://image.tmdb.org/t/p/w500$posterPath';
+  }
+
+  factory UpNextShow.fromJson(Map<String, dynamic> json) {
+    return UpNextShow(
+      title: json['title'] as String,
+      year: json['year'] as int,
+      genres: (json['genres'] as List<dynamic>).cast<String>(),
+      reason: json['reason'] as String,
+      popularityScore: json['popularity_score'] as int,
+      tmdbId: json['tmdb_id'] as int?,
+      posterPath: json['poster_path'] as String?,
+      seasons: json['seasons'] as int?,
+    );
+  }
+}
+
+/// Service for managing Up Next AI-powered show recommendations
+/// Up Next shows are personalized series recommendations generated weekly by AI
+/// Available to Mega (GPT-5-mini) and Ultra (GPT-5.1) subscribers
+class UpNextService {
+  static final UpNextService _instance = UpNextService._internal();
+  factory UpNextService() => _instance;
+  UpNextService._internal();
+
+  static const String _baseUrl = 'https://z-assistant.fly.dev';
+
+  DateTime? _lastFetchTime;
+  List<UpNextShow>? _cachedRecommendations;
+  bool _isGenerating = false;
+
+  List<UpNextShow>? get recommendations => _cachedRecommendations;
+  bool get hasRecommendations =>
+      _cachedRecommendations != null && _cachedRecommendations!.isNotEmpty;
+  bool get isGenerating => _isGenerating;
+
+  /// Get the current subscription tier for Up Next ("mega" or "ultra")
+  String get _subscriptionTier {
+    if (ZagreusUltra.isEnabled) return 'ultra';
+    if (ZagreusMega.isEnabled) return 'mega';
+    return 'none';
+  }
+
+  /// Check if recommendations need regeneration (> 7 days old or never generated)
+  /// Pass existing result to avoid redundant API calls
+  bool needsRegeneration({UpNextResult? existingResult}) {
+    if (!ZagreusMega.isEnabled) return false;
+
+    if (existingResult == null) return true;
+    if (!existingResult.success || existingResult.nextGenerationAt == null) {
+      return true; // No data or error, should try to generate
+    }
+
+    // Check if it's time for next generation
+    return DateTime.now().isAfter(existingResult.nextGenerationAt!);
+  }
+
+  /// Fetch cached Up Next recommendations from backend
+  Future<UpNextResult> fetchRecommendations() async {
+    print('\n═══════════════════════════════════════');
+    print('📺 UP NEXT FETCH STARTED');
+    print('═══════════════════════════════════════');
+
+    // Mega or Ultra required
+    if (!ZagreusMega.isEnabled) {
+      print('❌ FETCH BLOCKED: Mega or Ultra subscription required');
+      return UpNextResult.failure(
+        UpNextError.noMegaOrUltra,
+        'Mega or Ultra subscription required for Up Next',
+      );
+    }
+
+    try {
+      final deviceId = DeviceIdService().deviceId;
+      final hmacKey = HmacEncryptionService().hmacKey;
+
+      final response = await http.get(
+        Uri.parse('$_baseUrl/recommendations/up-next'),
+        headers: {
+          'X-Device-Id': deviceId,
+          'X-HMAC-Signature': hmacKey,
+          'X-Subscription-Tier': _subscriptionTier,
+        },
+      );
+
+      print('📡 Up Next response: ${response.statusCode}');
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        final recommendationsData = data['recommendations'] as List<dynamic>?;
+
+        if (recommendationsData == null || recommendationsData.isEmpty) {
+          print('📭 No recommendations yet');
+          _cachedRecommendations = [];
+          return UpNextResult.success(recommendations: []);
+        }
+
+        final recommendations = recommendationsData
+            .map((item) => UpNextShow.fromJson(item as Map<String, dynamic>))
+            .toList();
+
+        _cachedRecommendations = recommendations;
+        _lastFetchTime = DateTime.now();
+        _isGenerating = data['is_generating'] as bool? ?? false;
+
+        final generatedAt = data['generated_at'] != null
+            ? DateTime.parse(data['generated_at'] as String)
+            : null;
+        final nextGenerationAt = data['next_generation_at'] != null
+            ? DateTime.parse(data['next_generation_at'] as String)
+            : null;
+
+        print('✅ Fetched ${recommendations.length} up next shows');
+        print('   Generated: ${generatedAt?.toLocal()}');
+        print('   Next generation: ${nextGenerationAt?.toLocal()}');
+        print('═══════════════════════════════════════\n');
+
+        return UpNextResult.success(
+          recommendations: recommendations,
+          generatedAt: generatedAt,
+          nextGenerationAt: nextGenerationAt,
+        );
+      } else {
+        print('❌ HTTP ${response.statusCode}: ${response.body}');
+        return UpNextResult.failure(
+          UpNextError.fetchFailed,
+          'Failed to fetch: ${response.statusCode}',
+        );
+      }
+    } catch (e, stack) {
+      ZagLogger().error('Up Next fetch error', e, stack);
+      print('❌ EXCEPTION: $e');
+      print('═══════════════════════════════════════\n');
+      return UpNextResult.failure(UpNextError.unknown, e.toString());
+    }
+  }
+
+  /// Generate new Up Next recommendations
+  /// This triggers the backend to analyze library + watch history with AI
+  /// Mega users get GPT-5-mini, Ultra users get GPT-5.1
+  Future<UpNextResult> generateRecommendations({bool force = false}) async {
+    print('\n═══════════════════════════════════════');
+    print('📺 UP NEXT GENERATION STARTED');
+    print('═══════════════════════════════════════');
+    print('Force: $force');
+    print('Tier: $_subscriptionTier');
+
+    // Mega or Ultra required
+    if (!ZagreusMega.isEnabled) {
+      print('❌ GENERATION BLOCKED: Mega or Ultra subscription required');
+      return UpNextResult.failure(
+        UpNextError.noMegaOrUltra,
+        'Mega or Ultra subscription required for Up Next',
+      );
+    }
+
+    if (_isGenerating && !force) {
+      print('⏳ Already generating...');
+      return UpNextResult.failure(
+        UpNextError.alreadyGenerating,
+        'Up Next shows are already being generated',
+      );
+    }
+
+    try {
+      final deviceId = DeviceIdService().deviceId;
+      final hmacKey = HmacEncryptionService().hmacKey;
+
+      _isGenerating = true;
+
+      final response = await http.post(
+        Uri.parse('$_baseUrl/recommendations/up-next/generate'),
+        headers: {
+          'X-Device-Id': deviceId,
+          'X-HMAC-Signature': hmacKey,
+          'X-Subscription-Tier': _subscriptionTier,
+        },
+      );
+
+      print('📡 Generation response: ${response.statusCode}');
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+
+        if (data['status'] == 'up_to_date') {
+          print('✅ Up Next shows are already up to date');
+          print('   Age: ${data['age_days']} days');
+          _isGenerating = false;
+          return fetchRecommendations(); // Return existing
+        }
+
+        print('✅ Generation started successfully');
+        print('   Duration: ${data['generation_duration_ms']}ms');
+        print('   Count: ${data['recommendations_count']}');
+
+        // Fetch the fresh recommendations
+        _isGenerating = false;
+        return await fetchRecommendations();
+      } else if (response.statusCode == 409) {
+        print('⏳ Generation already in progress');
+        _isGenerating = false;
+        return UpNextResult.failure(
+          UpNextError.alreadyGenerating,
+          'Generation already in progress',
+        );
+      } else if (response.statusCode == 400) {
+        final error = json.decode(response.body);
+        print('❌ Library not synced: ${error['detail']}');
+        _isGenerating = false;
+        return UpNextResult.failure(
+          UpNextError.notSynced,
+          error['detail'] as String? ?? 'Library not synced',
+        );
+      } else {
+        print('❌ HTTP ${response.statusCode}: ${response.body}');
+        _isGenerating = false;
+        return UpNextResult.failure(
+          UpNextError.unknown,
+          'Generation failed: ${response.statusCode}',
+        );
+      }
+    } catch (e, stack) {
+      ZagLogger().error('Up Next generation error', e, stack);
+      print('❌ EXCEPTION: $e');
+      print('═══════════════════════════════════════\n');
+      _isGenerating = false;
+      return UpNextResult.failure(UpNextError.unknown, e.toString());
+    }
+  }
+
+  /// Convenience method to fetch or generate as needed
+  Future<UpNextResult> syncIfNeeded() async {
+    // First try to fetch existing - do this ONCE
+    final fetchResult = await fetchRecommendations();
+
+    if (fetchResult.success && fetchResult.recommendations!.isNotEmpty) {
+      // Check if regeneration is needed based on the result we just fetched
+      final needsRegen = needsRegeneration(existingResult: fetchResult);
+      if (!needsRegen) {
+        return fetchResult; // All good, return what we already have
+      }
+    }
+
+    // Generate new recommendations
+    return await generateRecommendations();
+  }
+}


### PR DESCRIPTION
Implements a parallel feature to "Deep Cuts" for movies, but focused on TV shows. Instead of finding hidden gems, this recommends popular/trending shows users should watch next based on their viewing patterns.

Frontend Changes:
- Create UpNextService (lib/services/up_next_service.dart) for API integration
  - Mirrors DeepCutsService structure for TV shows
  - Connects to /recommendations/up-next and /recommendations/up-next/generate endpoints
  - 7-day refresh cycle with popularity_score >= 6 filtering

- Add 'up_next' section to TV sections in discover_sections_editor.dart
  - Added to default TV sections list
  - Added section name mapping: 'Up Next'
  - Added icon: Icons.auto_awesome_rounded (matching Deep Cuts style)

- Implement Up Next UI in discover/route.dart
  - Add state variables: _upNextFuture, _upNextSyncInitialized, scroll controllers
  - Add _syncUpNextIfNeeded() for automatic background sync
  - Add section builder in _buildTVSections()
  - Implement _upNextSection() widget with purple Z branding
  - Implement _upNextEmptyState() for error/loading states
  - Implement _upNextShowCard() for individual show recommendations
  - Cards display: poster, AI-generated reason, tap to open in Sonarr
  - Uses TMDB /search/tv endpoint for show lookup

Backend API Endpoints (already implemented):
- GET /recommendations/up-next - Fetch cached recommendations
- POST /recommendations/up-next/generate - Trigger new generation

This matches the Deep Cuts UX but tailored for shows instead of movies.