### PR TITLE
Make TMDb ratings clickable to open in-app browser

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -27,6 +27,7 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
   bool _loading = true;
   bool _hasError = false;
   late final bool _isPremium;
+  int? _tmdbId;
 
   @override
   void initState() {
@@ -59,8 +60,10 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
 
       // Fetch TMDb rating
       double? tmdbRating;
+      int? tmdbId;
       if (widget.movie?.tmdbId != null) {
-        final tmdbData = await TMDBApi.getMovieDetails(widget.movie!.tmdbId!);
+        tmdbId = widget.movie!.tmdbId;
+        final tmdbData = await TMDBApi.getMovieDetails(tmdbId!);
         if (tmdbData != null && tmdbData['vote_average'] != null) {
           tmdbRating = (tmdbData['vote_average'] as num).toDouble();
         }
@@ -69,6 +72,7 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
       setState(() {
         _ratings = ratings;
         _tmdbRating = tmdbRating;
+        _tmdbId = tmdbId;
         _loading = false;
         _hasError = ratings == null && tmdbRating == null;
       });
@@ -124,6 +128,15 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
                 height: 30,
               ),
               _tmdbRating!.toStringAsFixed(1),
+              onTap: _tmdbId != null
+                  ? () {
+                      final link = ZagLinkedContent.theMovieDB(
+                        _tmdbId,
+                        LinkedContentType.MOVIE,
+                      );
+                      if (link != null) link.openLink();
+                    }
+                  : null,
             ),
           if (_ratings?.rottenTomatoes != null)
             _buildRating(

--- a/zagreus/lib/modules/sonarr/routes/series_details/widgets/ratings_tile.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/widgets/ratings_tile.dart
@@ -26,6 +26,7 @@ class _SonarrRatingsTileState extends State<SonarrRatingsTile> {
   bool _loading = true;
   bool _hasError = false;
   late final bool _isPremium;
+  int? _tmdbId;
 
   @override
   void initState() {
@@ -56,7 +57,8 @@ class _SonarrRatingsTileState extends State<SonarrRatingsTile> {
 
       // Fetch TMDb rating by looking up TMDb ID from IMDb ID
       double? tmdbRating;
-      final tmdbId = await TMDBApi.getTmdbIdFromImdb(widget.series!.imdbId!);
+      int? tmdbId;
+      tmdbId = await TMDBApi.getTmdbIdFromImdb(widget.series!.imdbId!);
       if (tmdbId != null) {
         final tmdbData = await TMDBApi.getTVShowDetails(tmdbId);
         if (tmdbData != null && tmdbData['vote_average'] != null) {
@@ -67,6 +69,7 @@ class _SonarrRatingsTileState extends State<SonarrRatingsTile> {
       setState(() {
         _ratings = ratings;
         _tmdbRating = tmdbRating;
+        _tmdbId = tmdbId;
         _loading = false;
         _hasError = ratings == null && tmdbRating == null;
       });
@@ -123,6 +126,15 @@ class _SonarrRatingsTileState extends State<SonarrRatingsTile> {
                 height: 30,
               ),
               _tmdbRating!.toStringAsFixed(1),
+              onTap: _tmdbId != null
+                  ? () {
+                      final link = ZagLinkedContent.theMovieDB(
+                        _tmdbId,
+                        LinkedContentType.SERIES,
+                      );
+                      if (link != null) link.openLink();
+                    }
+                  : null,
             ),
         ],
       ),


### PR DESCRIPTION
- Added onTap handlers to TMDb ratings for both movies and TV shows
- Movies open TMDb movie page, TV shows open TMDb series page
- Uses existing ZagLinkedContent.theMovieDB() helper
- Cached tmdbId during rating fetch to use in link generation