### PR TITLE
Fix build error: Add missing _openTVShowInSonarr method

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -5897,6 +5897,10 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     }
   }
 
+  Future<void> _openTVShowInSonarr({required int tmdbId, required String title}) async {
+    await _openSeriesInSonarr(tmdbId: tmdbId, title: title);
+  }
+
   Widget _mostAnticipatedShowsSection() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
The _openTVShowInSonarr method was being called in the Up Next section but was not defined. Added it as a wrapper around _openSeriesInSonarr to handle opening TV shows in Sonarr from the Up Next recommendations.