### PR TITLE
Refactor subscription sharing to use email-based grants

### DIFF
--- a/zagreus-cloud-functions/supabase/migrations/20241123_create_subscription_shares.sql
+++ b/zagreus-cloud-functions/supabase/migrations/20241123_create_subscription_shares.sql
@@ -9,29 +9,25 @@ CREATE TABLE IF NOT EXISTS public.subscription_shares (
   owner_product_id TEXT NOT NULL, -- mega.monthly, ultra.yearly, etc
   owner_expires_at TIMESTAMPTZ NOT NULL, -- Synced from RevenueCat by master device
 
-  -- Share code for redemption
-  share_code TEXT UNIQUE NOT NULL, -- 8-character code like ABC123XY
-
-  -- Shared with (NULL until redeemed)
-  shared_with_user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
-  shared_with_email TEXT, -- For display purposes
+  -- Shared with (email is required, user_id populated when they sign in)
+  shared_with_email TEXT NOT NULL, -- Email to grant access to
+  shared_with_user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE, -- Populated on first sign-in
 
   -- Status
-  status TEXT NOT NULL DEFAULT 'active', -- active, revoked, redeemed
+  status TEXT NOT NULL DEFAULT 'active', -- active, revoked
 
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW(),
-  redeemed_at TIMESTAMPTZ, -- When the code was redeemed
 
-  -- Prevent duplicate shares per owner+recipient (only after redemption)
-  UNIQUE(owner_user_id, shared_with_user_id)
+  -- Prevent duplicate shares per owner+email
+  UNIQUE(owner_user_id, shared_with_email)
 );
 
 -- Indexes
 CREATE INDEX IF NOT EXISTS idx_shares_owner ON public.subscription_shares(owner_user_id);
 CREATE INDEX IF NOT EXISTS idx_shares_recipient ON public.subscription_shares(shared_with_user_id);
+CREATE INDEX IF NOT EXISTS idx_shares_email ON public.subscription_shares(shared_with_email);
 CREATE INDEX IF NOT EXISTS idx_shares_status ON public.subscription_shares(status);
-CREATE INDEX IF NOT EXISTS idx_shares_code ON public.subscription_shares(share_code);
 
 -- RLS
 ALTER TABLE public.subscription_shares ENABLE ROW LEVEL SECURITY;
@@ -42,11 +38,14 @@ CREATE POLICY "Owners can view their shares"
   FOR SELECT
   USING (auth.uid() = owner_user_id);
 
--- Recipients can see shares granted to them
+-- Recipients can see shares granted to them (by user_id or email)
 CREATE POLICY "Recipients can view their shares"
   ON public.subscription_shares
   FOR SELECT
-  USING (auth.uid() = shared_with_user_id);
+  USING (
+    auth.uid() = shared_with_user_id OR
+    auth.email() = shared_with_email
+  );
 
 -- Only owners can grant shares (with quota check)
 CREATE POLICY "Owners can grant shares"
@@ -95,12 +94,13 @@ END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- Function to check if user has Pro access (direct OR shared)
-CREATE OR REPLACE FUNCTION has_pro_access(p_user_id UUID)
+CREATE OR REPLACE FUNCTION has_pro_access(p_user_id UUID, p_user_email TEXT)
 RETURNS TABLE (
   has_access BOOLEAN,
   access_type TEXT, -- 'direct', 'shared', or NULL
   expires_at TIMESTAMPTZ,
-  product_id TEXT
+  product_id TEXT,
+  share_id UUID -- For auto-populating user_id on first sign-in
 ) AS $$
 BEGIN
   -- Check direct subscription first
@@ -109,7 +109,8 @@ BEGIN
     TRUE as has_access,
     'direct'::TEXT as access_type,
     s.expires_date as expires_at,
-    s.product_id
+    s.product_id,
+    NULL::UUID as share_id
   FROM public.subscriptions s
   WHERE s.user_id = p_user_id
     AND s.status = 'active'
@@ -117,14 +118,15 @@ BEGIN
   ORDER BY s.expires_date DESC
   LIMIT 1;
 
-  -- If no direct subscription, check shared access
+  -- If no direct subscription, check shared access by user_id
   IF NOT FOUND THEN
     RETURN QUERY
     SELECT
       TRUE as has_access,
       'shared'::TEXT as access_type,
       sh.owner_expires_at as expires_at,
-      sh.owner_product_id as product_id
+      sh.owner_product_id as product_id,
+      sh.id as share_id
     FROM public.subscription_shares sh
     WHERE sh.shared_with_user_id = p_user_id
       AND sh.status = 'active'
@@ -133,131 +135,102 @@ BEGIN
     LIMIT 1;
   END IF;
 
+  -- If still not found, check by email (for first-time sign-in)
+  IF NOT FOUND THEN
+    RETURN QUERY
+    SELECT
+      TRUE as has_access,
+      'shared'::TEXT as access_type,
+      sh.owner_expires_at as expires_at,
+      sh.owner_product_id as product_id,
+      sh.id as share_id
+    FROM public.subscription_shares sh
+    WHERE sh.shared_with_email = p_user_email
+      AND sh.status = 'active'
+      AND sh.owner_expires_at > NOW()
+    ORDER BY sh.owner_expires_at DESC
+    LIMIT 1;
+  END IF;
+
   -- No access
   IF NOT FOUND THEN
-    RETURN QUERY SELECT FALSE, NULL::TEXT, NULL::TIMESTAMPTZ, NULL::TEXT;
+    RETURN QUERY SELECT FALSE, NULL::TEXT, NULL::TIMESTAMPTZ, NULL::TEXT, NULL::UUID;
   END IF;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
--- Function to generate random share code
-CREATE OR REPLACE FUNCTION generate_share_code()
-RETURNS TEXT AS $$
-DECLARE
-  v_code TEXT;
-  v_exists BOOLEAN;
-BEGIN
-  LOOP
-    -- Generate 8-character alphanumeric code
-    v_code := UPPER(SUBSTRING(MD5(RANDOM()::TEXT) FROM 1 FOR 8));
-
-    -- Check if code already exists
-    SELECT EXISTS(
-      SELECT 1 FROM public.subscription_shares WHERE share_code = v_code
-    ) INTO v_exists;
-
-    EXIT WHEN NOT v_exists;
-  END LOOP;
-
-  RETURN v_code;
-END;
-$$ LANGUAGE plpgsql;
-
--- Function to create a share code (with quota validation)
-CREATE OR REPLACE FUNCTION create_share_code(
+-- Function to grant share by email (with quota validation)
+CREATE OR REPLACE FUNCTION grant_share_by_email(
   p_owner_user_id UUID,
   p_owner_product_id TEXT,
-  p_owner_expires_at TIMESTAMPTZ
+  p_owner_expires_at TIMESTAMPTZ,
+  p_recipient_email TEXT
 )
 RETURNS JSON AS $$
 DECLARE
   v_remaining INTEGER;
-  v_share_code TEXT;
   v_share_id UUID;
+  v_owner_email TEXT;
 BEGIN
+  -- Get owner email to prevent self-sharing
+  SELECT email INTO v_owner_email
+  FROM auth.users
+  WHERE id = p_owner_user_id;
+
+  -- Can't share with yourself
+  IF LOWER(v_owner_email) = LOWER(p_recipient_email) THEN
+    RETURN json_build_object('success', false, 'error', 'Cannot share with yourself');
+  END IF;
+
   -- Check quota
   v_remaining := get_remaining_shares(p_owner_user_id, p_owner_product_id);
   IF v_remaining <= 0 THEN
     RETURN json_build_object('success', false, 'error', 'No shares remaining');
   END IF;
 
-  -- Generate unique share code
-  v_share_code := generate_share_code();
-
-  -- Insert share with code (no recipient yet)
+  -- Insert share with email (user_id gets populated on first sign-in)
   INSERT INTO public.subscription_shares (
     owner_user_id,
     owner_product_id,
     owner_expires_at,
-    share_code,
+    shared_with_email,
     status
   ) VALUES (
     p_owner_user_id,
     p_owner_product_id,
     p_owner_expires_at,
-    v_share_code,
+    LOWER(p_recipient_email), -- Normalize to lowercase
     'active'
   )
   RETURNING id INTO v_share_id;
 
   RETURN json_build_object(
     'success', true,
-    'share_id', v_share_id,
-    'share_code', v_share_code
+    'share_id', v_share_id
   );
+EXCEPTION
+  WHEN unique_violation THEN
+    RETURN json_build_object('success', false, 'error', 'Already shared with this email');
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
--- Function to redeem a share code
-CREATE OR REPLACE FUNCTION redeem_share_code(
+-- Function to link email-based share to user on sign-in
+CREATE OR REPLACE FUNCTION link_email_share_to_user(
   p_user_id UUID,
-  p_share_code TEXT
+  p_user_email TEXT,
+  p_share_id UUID
 )
-RETURNS JSON AS $$
-DECLARE
-  v_share RECORD;
-  v_user_email TEXT;
+RETURNS BOOLEAN AS $$
 BEGIN
-  -- Get user email
-  SELECT email INTO v_user_email
-  FROM auth.users
-  WHERE id = p_user_id;
-
-  -- Find the share
-  SELECT * INTO v_share
-  FROM public.subscription_shares
-  WHERE share_code = p_share_code
-    AND status = 'active'
-    AND owner_expires_at > NOW();
-
-  IF v_share IS NULL THEN
-    RETURN json_build_object('success', false, 'error', 'Invalid or expired share code');
-  END IF;
-
-  -- Can't redeem your own share
-  IF v_share.owner_user_id = p_user_id THEN
-    RETURN json_build_object('success', false, 'error', 'Cannot redeem your own share');
-  END IF;
-
-  -- Check if already redeemed by someone else
-  IF v_share.shared_with_user_id IS NOT NULL THEN
-    RETURN json_build_object('success', false, 'error', 'Share code already used');
-  END IF;
-
-  -- Redeem the share
   UPDATE public.subscription_shares
   SET
     shared_with_user_id = p_user_id,
-    shared_with_email = v_user_email,
-    redeemed_at = NOW(),
     updated_at = NOW()
-  WHERE share_code = p_share_code;
+  WHERE id = p_share_id
+    AND shared_with_email = LOWER(p_user_email)
+    AND shared_with_user_id IS NULL;
 
-  RETURN json_build_object(
-    'success', true,
-    'expires_at', v_share.owner_expires_at,
-    'product_id', v_share.owner_product_id
-  );
+  RETURN FOUND;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 

--- a/zagreus/lib/modules/settings/routes/subscriptions/route.dart
+++ b/zagreus/lib/modules/settings/routes/subscriptions/route.dart
@@ -40,25 +40,9 @@ class _State extends State<SubscriptionsRoute> with ZagScrollControllerMixin {
   }
 
   PreferredSizeWidget _appBar() {
-    final bool isPro = ZagreusPro.isEnabled;
-    final bool isMega = ZagreusMega.isEnabled;
-    final bool isUltra = ZagreusUltra.isEnabled;
-    final bool hasAnySub = isPro || isMega || isUltra;
-
     return ZagAppBar(
       title: 'Subscriptions',
       scrollControllers: [scrollController],
-      actions: [
-        // Only show enter code button for users with NO subscription
-        if (ZagSupabaseAuth().isSignedIn && !hasAnySub)
-          IconButton(
-            icon: Icon(
-              Icons.tag_rounded, // Pound sign - retro code entry vibe
-              color: ZagColours.currentAccent,
-            ),
-            onPressed: _showEnterShareCodeDialog,
-          ),
-      ],
     );
   }
 
@@ -821,88 +805,6 @@ class _State extends State<SubscriptionsRoute> with ZagScrollControllerMixin {
 
     // Refresh the UI to show updated Pro status
     setState(() {});
-  }
-
-  void _showEnterShareCodeDialog() {
-    final TextEditingController codeController = TextEditingController();
-
-    ZagDialog.dialog(
-      context: context,
-      title: 'Enter Share Code',
-      customContent: ZagDialog.content(
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Enter the share code you received:',
-                  style: const TextStyle(fontSize: ZagUI.FONT_SIZE_H2),
-                ),
-                const SizedBox(height: 16),
-                TextField(
-                  controller: codeController,
-                  autocorrect: false,
-                  textCapitalization: TextCapitalization.characters,
-                  decoration: InputDecoration(
-                    labelText: 'Share Code',
-                    hintText: 'ABC123XY',
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          ZagDialog.tile(
-            icon: Icons.check_rounded,
-            iconColor: ZagColours.currentAccent,
-            text: 'Redeem',
-            onTap: () {
-              Navigator.of(context).pop();
-              _redeemShareCode(codeController.text.trim().toUpperCase());
-            },
-          ),
-        ],
-      ),
-      contentPadding: ZagDialog.listDialogContentPadding(),
-    );
-  }
-
-  Future<void> _redeemShareCode(String code) async {
-    if (code.isEmpty) {
-      showZagInfoSnackBar(
-        title: 'Invalid Code',
-        message: 'Please enter a share code',
-      );
-      return;
-    }
-
-    showZagInfoSnackBar(
-      title: 'Redeeming',
-      message: 'Checking share code...',
-    );
-
-    final result = await ZagSupabaseShares().redeemShareCode(code);
-
-    if (result.success) {
-      showZagInfoSnackBar(
-        title: 'Success',
-        message: 'Pro access activated!',
-      );
-
-      // Refresh subscription status
-      SubscriptionService().refresh();
-
-      setState(() {});
-    } else {
-      showZagInfoSnackBar(
-        title: 'Failed',
-        message: result.error ?? 'Invalid or expired share code',
-      );
-    }
   }
 
   @override

--- a/zagreus/lib/modules/settings/routes/subscriptions/shares_route.dart
+++ b/zagreus/lib/modules/settings/routes/subscriptions/shares_route.dart
@@ -102,7 +102,7 @@ class _State extends State<SharesManagementRoute> with ZagScrollControllerMixin 
             title: 'Shared With You',
             body: [
               TextSpan(
-                text: 'You have Pro access shared from ${_receivedShares.first.sharedWithEmail ?? "another user"}',
+                text: 'You have Pro access shared by another user • Expires ${_formatDate(_receivedShares.first.ownerExpiresAt)}',
               ),
             ],
             trailing: ZagIconButton(
@@ -135,23 +135,19 @@ class _State extends State<SharesManagementRoute> with ZagScrollControllerMixin 
           // List of granted shares
           if (_grantedShares.isNotEmpty)
             ..._grantedShares.map((share) => ZagBlock(
-              title: share.isRedeemed
-                  ? (share.sharedWithEmail ?? 'Redeemed')
-                  : 'Code: ${share.shareCode}',
+              title: share.sharedWithEmail,
               body: [
                 TextSpan(
-                  text: share.isRedeemed
-                      ? 'Redeemed • Expires ${_formatDate(share.ownerExpiresAt)}'
-                      : 'Not redeemed yet • Tap to view code',
+                  text: share.isActive
+                      ? 'Active • Expires ${_formatDate(share.ownerExpiresAt)}'
+                      : 'Pending sign-in • Expires ${_formatDate(share.ownerExpiresAt)}',
                 ),
               ],
               trailing: ZagIconButton(
                 icon: Icons.close_rounded,
                 color: ZagColours.red,
               ),
-              onTap: () => share.isRedeemed
-                  ? _confirmRevokeShare(share)
-                  : _showShareCode(share),
+              onTap: () => _confirmRevokeShare(share),
             )),
         ],
 
@@ -194,58 +190,49 @@ class _State extends State<SharesManagementRoute> with ZagScrollControllerMixin 
   }
 
   void _showGrantShareDialog() {
-    _createShareCode();
-  }
+    final emailController = TextEditingController();
 
-  void _showShareCode(SubscriptionShare share) {
     ZagDialog.dialog(
       context: context,
-      title: 'Share Code',
+      title: 'Share Pro Access',
       customContent: ZagDialog.content(
         children: [
           Padding(
-            padding: const EdgeInsets.all(16.0),
+            padding: ZagDialog.textDialogContentPadding(),
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
-                  'Share this code with your friend or family member:',
+                  'Enter the email address of the person you want to share Pro access with:',
                   style: const TextStyle(fontSize: ZagUI.FONT_SIZE_H2),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 24),
-                Container(
-                  padding: const EdgeInsets.all(20),
-                  decoration: BoxDecoration(
-                    color: ZagColours.currentAccent.withOpacity(0.1),
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(
-                      color: ZagColours.currentAccent.withOpacity(0.3),
-                      width: 2,
-                    ),
-                  ),
-                  child: Text(
-                    share.shareCode,
-                    style: TextStyle(
-                      fontSize: 32,
-                      fontWeight: FontWeight.bold,
-                      letterSpacing: 4,
-                      color: ZagColours.currentAccent,
-                      fontFamily: 'monospace',
-                    ),
-                  ),
                 ),
                 const SizedBox(height: 16),
-                Text(
-                  'They can redeem it in Settings > System > Enter Share Code',
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: Theme.of(context).textTheme.bodySmall?.color?.withOpacity(0.7),
+                TextField(
+                  controller: emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  autocorrect: false,
+                  decoration: InputDecoration(
+                    hintText: 'email@example.com',
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
                   ),
-                  textAlign: TextAlign.center,
                 ),
               ],
             ),
+          ),
+          ZagDialog.tile(
+            icon: Icons.person_add_rounded,
+            iconColor: ZagColours.currentAccent,
+            text: 'Grant Access',
+            onTap: () {
+              Navigator.of(context).pop();
+              final email = emailController.text.trim();
+              if (email.isNotEmpty) {
+                _grantShareByEmail(email);
+              }
+            },
           ),
         ],
       ),
@@ -253,7 +240,7 @@ class _State extends State<SharesManagementRoute> with ZagScrollControllerMixin 
     );
   }
 
-  Future<void> _createShareCode() async {
+  Future<void> _grantShareByEmail(String email) async {
     if (_currentProductId == null) {
       showZagInfoSnackBar(
         title: 'Error',
@@ -263,8 +250,8 @@ class _State extends State<SharesManagementRoute> with ZagScrollControllerMixin 
     }
 
     showZagInfoSnackBar(
-      title: 'Creating Share Code',
-      message: 'Generating code...',
+      title: 'Granting Access',
+      message: 'Creating share...',
     );
 
     // Get expiry from local tier
@@ -289,24 +276,22 @@ class _State extends State<SharesManagementRoute> with ZagScrollControllerMixin 
       return;
     }
 
-    final result = await ZagSupabaseShares().createShareCode(
+    final result = await ZagSupabaseShares().grantShareByEmail(
+      email: email,
       productId: _currentProductId!,
       expiresAt: expiresAt,
     );
 
-    if (result.success && result.shareCode != null) {
-      await _loadShares(); // Reload shares
-
-      // Show the new share code
-      final newShare = _grantedShares.firstWhere(
-        (s) => s.shareCode == result.shareCode,
-        orElse: () => _grantedShares.first,
+    if (result.success) {
+      showZagInfoSnackBar(
+        title: 'Success',
+        message: 'Pro access shared with $email',
       );
-      _showShareCode(newShare);
+      _loadShares(); // Reload shares
     } else {
       showZagInfoSnackBar(
         title: 'Failed',
-        message: result.error ?? 'Could not create share code',
+        message: result.error ?? 'Could not grant share',
       );
     }
   }

--- a/zagreus/lib/supabase/subscription_shares.dart
+++ b/zagreus/lib/supabase/subscription_shares.dart
@@ -9,29 +9,25 @@ class SubscriptionShare {
   final String ownerUserId;
   final String ownerProductId;
   final DateTime ownerExpiresAt;
-  final String shareCode; // 8-character redemption code
-  final String? sharedWithUserId; // NULL until redeemed
-  final String? sharedWithEmail;
-  final String status; // 'active', 'revoked', 'redeemed'
+  final String sharedWithEmail; // Email address granted access
+  final String? sharedWithUserId; // NULL until user signs in
+  final String status; // 'active', 'revoked'
   final DateTime createdAt;
   final DateTime updatedAt;
-  final DateTime? redeemedAt;
 
   SubscriptionShare({
     required this.id,
     required this.ownerUserId,
     required this.ownerProductId,
     required this.ownerExpiresAt,
-    required this.shareCode,
+    required this.sharedWithEmail,
     this.sharedWithUserId,
-    this.sharedWithEmail,
     required this.status,
     required this.createdAt,
     required this.updatedAt,
-    this.redeemedAt,
   });
 
-  bool get isRedeemed => sharedWithUserId != null;
+  bool get isActive => sharedWithUserId != null;
 
   factory SubscriptionShare.fromMap(Map<String, dynamic> map) {
     return SubscriptionShare(
@@ -39,15 +35,11 @@ class SubscriptionShare {
       ownerUserId: map['owner_user_id'] as String,
       ownerProductId: map['owner_product_id'] as String,
       ownerExpiresAt: DateTime.parse(map['owner_expires_at'] as String),
-      shareCode: map['share_code'] as String,
+      sharedWithEmail: map['shared_with_email'] as String,
       sharedWithUserId: map['shared_with_user_id'] as String?,
-      sharedWithEmail: map['shared_with_email'] as String?,
       status: map['status'] as String,
       createdAt: DateTime.parse(map['created_at'] as String),
       updatedAt: DateTime.parse(map['updated_at'] as String),
-      redeemedAt: map['redeemed_at'] != null
-          ? DateTime.parse(map['redeemed_at'] as String)
-          : null,
     );
   }
 }
@@ -58,12 +50,14 @@ class ProAccessResult {
   final String? accessType; // 'direct', 'shared', or null
   final DateTime? expiresAt;
   final String? productId;
+  final String? shareId; // For linking email to user on first sign-in
 
   ProAccessResult({
     required this.hasAccess,
     this.accessType,
     this.expiresAt,
     this.productId,
+    this.shareId,
   });
 
   bool get isDirect => accessType == 'direct';
@@ -79,6 +73,7 @@ class ZagSupabaseShares {
   SupabaseClient get _client => ZagSupabaseDatabase.instance;
 
   /// Check if user has Pro access (direct subscription OR shared)
+  /// Auto-links email-based shares to user on first sign-in
   Future<ProAccessResult> checkProAccess() async {
     if (!ZagSupabaseAuth().isSignedIn) {
       return ProAccessResult(hasAccess: false);
@@ -86,8 +81,11 @@ class ZagSupabaseShares {
 
     try {
       final userId = ZagSupabaseAuth().uid;
+      final userEmail = ZagSupabaseAuth().email;
+
       final response = await _client.rpc('has_pro_access', params: {
         'p_user_id': userId,
+        'p_user_email': userEmail,
       }) as List;
 
       if (response.isEmpty) {
@@ -95,6 +93,13 @@ class ZagSupabaseShares {
       }
 
       final result = response.first;
+      final shareId = result['share_id'] as String?;
+
+      // If we got a share_id, link the email to this user
+      if (shareId != null && userEmail != null) {
+        await linkEmailShareToUser(shareId, userEmail);
+      }
+
       return ProAccessResult(
         hasAccess: result['has_access'] as bool? ?? false,
         accessType: result['access_type'] as String?,
@@ -102,6 +107,7 @@ class ZagSupabaseShares {
             ? DateTime.parse(result['expires_at'] as String)
             : null,
         productId: result['product_id'] as String?,
+        shareId: shareId,
       );
     } catch (error, stack) {
       ZagLogger().error('Failed to check Pro access', error, stack);
@@ -149,17 +155,20 @@ class ZagSupabaseShares {
     }
   }
 
-  /// Get shares granted to the current user
+  /// Get shares granted to the current user (by user_id or email)
   Future<List<SubscriptionShare>> getReceivedShares() async {
     if (!ZagSupabaseAuth().isSignedIn) return [];
 
     try {
       final userId = ZagSupabaseAuth().uid;
+      final userEmail = ZagSupabaseAuth().email;
+
+      // Query by user_id OR email
       final response = await _client
           .from('subscription_shares')
           .select()
-          .eq('shared_with_user_id', userId!)
           .eq('status', 'active')
+          .or('shared_with_user_id.eq.$userId,shared_with_email.eq.${userEmail?.toLowerCase()}')
           .order('created_at', ascending: false);
 
       return (response as List)
@@ -171,21 +180,23 @@ class ZagSupabaseShares {
     }
   }
 
-  /// Create a share code
-  Future<({bool success, String? error, String? shareId, String? shareCode})> createShareCode({
+  /// Grant share to an email address
+  Future<({bool success, String? error, String? shareId})> grantShareByEmail({
+    required String email,
     required String productId,
     required DateTime expiresAt,
   }) async {
     if (!ZagSupabaseAuth().isSignedIn) {
-      return (success: false, error: 'Not signed in', shareId: null, shareCode: null);
+      return (success: false, error: 'Not signed in', shareId: null);
     }
 
     try {
       final userId = ZagSupabaseAuth().uid;
-      final response = await _client.rpc('create_share_code', params: {
+      final response = await _client.rpc('grant_share_by_email', params: {
         'p_owner_user_id': userId,
         'p_owner_product_id': productId,
         'p_owner_expires_at': expiresAt.toUtc().toIso8601String(),
+        'p_recipient_email': email.toLowerCase().trim(),
       });
 
       final result = response as Map<String, dynamic>;
@@ -193,35 +204,29 @@ class ZagSupabaseShares {
         success: result['success'] as bool? ?? false,
         error: result['error'] as String?,
         shareId: result['share_id'] as String?,
-        shareCode: result['share_code'] as String?,
       );
     } catch (error, stack) {
-      ZagLogger().error('Failed to create share code', error, stack);
-      return (success: false, error: error.toString(), shareId: null, shareCode: null);
+      ZagLogger().error('Failed to grant share by email', error, stack);
+      return (success: false, error: error.toString(), shareId: null);
     }
   }
 
-  /// Redeem a share code
-  Future<({bool success, String? error})> redeemShareCode(String code) async {
-    if (!ZagSupabaseAuth().isSignedIn) {
-      return (success: false, error: 'Not signed in');
-    }
+  /// Link email-based share to user (called automatically on sign-in)
+  Future<bool> linkEmailShareToUser(String shareId, String email) async {
+    if (!ZagSupabaseAuth().isSignedIn) return false;
 
     try {
       final userId = ZagSupabaseAuth().uid;
-      final response = await _client.rpc('redeem_share_code', params: {
+      final response = await _client.rpc('link_email_share_to_user', params: {
         'p_user_id': userId,
-        'p_share_code': code,
+        'p_user_email': email.toLowerCase().trim(),
+        'p_share_id': shareId,
       });
 
-      final result = response as Map<String, dynamic>;
-      return (
-        success: result['success'] as bool? ?? false,
-        error: result['error'] as String?,
-      );
+      return response as bool? ?? false;
     } catch (error, stack) {
-      ZagLogger().error('Failed to redeem share code', error, stack);
-      return (success: false, error: error.toString());
+      ZagLogger().error('Failed to link email share to user', error, stack);
+      return false;
     }
   }
 


### PR DESCRIPTION
- Changed from share codes to email-based sharing for better control
- Mega/Ultra users now enter recipient email addresses directly
- Recipients automatically get Pro access when they sign in
- No UI needed for recipients - access is granted automatically
- Updated database schema to store email addresses
- Added auto-linking of email shares to user_id on first sign-in
- Removed share code generation and redemption UI
- Removed pound sign redemption button from app bar
- Simpler UX: granter enters email, recipient just signs in