### PR TITLE
Fix: Auto-migrate Up Next and Deep Cuts sections to existing users

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -1829,13 +1829,21 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     // Get saved order or use default
     final savedOrder =
         ZagreusDatabase.DISCOVER_MOVIES_SECTION_ORDER.read() as List;
-    final sectionOrder =
+    var sectionOrder =
         savedOrder.isNotEmpty ? List<String>.from(savedOrder) : defaultOrder;
+
+    // Migration: Add 'most_anticipated_movies' if missing
     if (!sectionOrder.contains('most_anticipated_movies')) {
       final popularIndex = sectionOrder.indexOf('popular_movies');
       final insertIndex =
           popularIndex == -1 ? sectionOrder.length : popularIndex + 1;
       sectionOrder.insert(insertIndex, 'most_anticipated_movies');
+    }
+
+    // Migration: Add 'deep_cuts' to existing saved orders if missing
+    if (savedOrder.isNotEmpty && !sectionOrder.contains('deep_cuts')) {
+      sectionOrder.add('deep_cuts');
+      ZagreusDatabase.DISCOVER_MOVIES_SECTION_ORDER.update(sectionOrder);
     }
 
     // Map of section builders
@@ -1939,8 +1947,14 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
 
     // Get saved order or use default
     final savedOrder = ZagreusDatabase.DISCOVER_TV_SECTION_ORDER.read() as List;
-    final sectionOrder =
+    var sectionOrder =
         savedOrder.isNotEmpty ? List<String>.from(savedOrder) : defaultOrder;
+
+    // Migration: Add 'up_next' to existing saved orders if missing
+    if (savedOrder.isNotEmpty && !sectionOrder.contains('up_next')) {
+      sectionOrder.add('up_next');
+      ZagreusDatabase.DISCOVER_TV_SECTION_ORDER.update(sectionOrder);
+    }
 
     // Map of section builders
     final sectionBuilders = <String, Widget Function()>{


### PR DESCRIPTION
When Up Next and Deep Cuts were added, users with saved custom section orders didn't automatically get these new sections. This adds migration logic that automatically adds 'up_next' and 'deep_cuts' to existing saved section orders when the dashboard loads.

- Adds migration for 'up_next' in TV sections
- Adds migration for 'deep_cuts' in movie sections
- Follows same pattern as existing 'most_anticipated_movies' migration

Fixes issue where Mega/Ultra users couldn't see Up Next despite having the correct subscription tier.