### PR TITLE
Investigate search results scrolling issue

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -2412,7 +2412,14 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
               : 0.0;
           final matchScore = computeMatchScore(item);
           final yearScore = computeYearScore(extractYear(item));
-          final mediaScore = mediaPriority(item);
+          var mediaScore = mediaPriority(item);
+
+          // Boost person results when there's a strong name match
+          // This ensures exact person matches (e.g., "Marlon Brando") appear at the top
+          final mediaType = item['media_type'] as String?;
+          if (mediaType == 'person' && matchScore >= 0.88) {
+            mediaScore = 1.0;
+          }
 
           return (mediaScore * 40) +
               (matchScore * 50) +


### PR DESCRIPTION
When searching for people (e.g., "Marlon Brando"), person objects were appearing far down in results due to lower media type priority (0.5 vs 1.0 for movies/TV).

This fix boosts person results to full priority (1.0) when the match score is >= 0.88, which includes exact matches and strong partial matches. This ensures that searching for a person's name will show their person object near the top of the results.