### PR TITLE
Add Trakt to iOS LSApplicationQueriesSchemes

### DIFF
--- a/zagreus/ios/Runner/Info.plist
+++ b/zagreus/ios/Runner/Info.plist
@@ -43,6 +43,7 @@
 		<string>https</string>
 		<string>imdb</string>
 		<string>letterboxd</string>
+		<string>trakt</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
This allows the app to detect if the Trakt app is installed on iOS. Trakt links already use LaunchMode.externalNonBrowserApplication and Trakt supports universal links via their apple-app-site-association file, so links should automatically open in the Trakt app when installed.