### PR TITLE
Fix Trakt app deep linking by using direct URLs with IMDB IDs

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/sheets/links.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/sheets/links.dart
@@ -18,7 +18,7 @@ class LinksSheet extends ZagBottomModalSheet {
         ZagLinkedContent.theMovieDB(movie.tmdbId, LinkedContentType.MOVIE);
     final letterboxd = ZagLinkedContent.letterboxd(movie.tmdbId);
     final trakt =
-        ZagLinkedContent.trakt(movie.tmdbId, LinkedContentType.MOVIE);
+        ZagLinkedContent.trakt(movie.imdbId, LinkedContentType.MOVIE);
     final youtube = ZagLinkedContent.youtube(movie.youTubeTrailerId);
 
     return ZagListViewModal(

--- a/zagreus/lib/modules/sonarr/routes/series_details/sheets/links.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/sheets/links.dart
@@ -17,7 +17,7 @@ class LinksSheet extends ZagBottomModalSheet {
     final tvdb =
         ZagLinkedContent.theTVDB(series.tvdbId, LinkedContentType.SERIES);
     final trakt =
-        ZagLinkedContent.trakt(series.tvdbId, LinkedContentType.SERIES);
+        ZagLinkedContent.trakt(series.imdbId, LinkedContentType.SERIES);
     final tvMaze = ZagLinkedContent.tvMaze(series.tvMazeId);
 
     return ZagListViewModal(

--- a/zagreus/lib/utils/links.dart
+++ b/zagreus/lib/utils/links.dart
@@ -93,15 +93,15 @@ enum ZagLinkedContent {
     }
   }
 
-  static String? trakt(int? id, LinkedContentType type) {
-    if (id == null) return null;
+  static String? trakt(String? imdbId, LinkedContentType type) {
+    if (imdbId == null) return null;
     const base = 'https://trakt.tv';
 
     switch (type) {
       case LinkedContentType.MOVIE:
-        return '$base/search/tmdb/$id?id_type=movie';
+        return '$base/movies/$imdbId';
       case LinkedContentType.SERIES:
-        return '$base/search/tvdb/$id?id_type=show';
+        return '$base/shows/$imdbId';
       default:
         throw UnsupportedError('$type content type is not supported');
     }


### PR DESCRIPTION
Changed Trakt URL format from search URLs to direct movie/show URLs:
- Movies: https://trakt.tv/movies/{imdbId} (was /search/tmdb/{tmdbId})
- Shows: https://trakt.tv/shows/{imdbId} (was /search/tvdb/{tvdbId})

These new URL paths (/movies/* and /shows/*) match Trakt's universal links configuration, so they will now open in the Trakt app instead of the browser.

The search URLs were not in Trakt's apple-app-site-association file, which is why they were opening in the browser despite using the correct launch mode.