### PR TITLE
Add Rotten Tomatoes app deep linking via search

### DIFF
--- a/zagreus/ios/Runner/Info.plist
+++ b/zagreus/ios/Runner/Info.plist
@@ -44,6 +44,7 @@
 		<string>imdb</string>
 		<string>letterboxd</string>
 		<string>trakt</string>
+		<string>rottentomatoes</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -145,6 +145,10 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
                 height: 20,
               ),
               _ratings!.rottenTomatoes!,
+              onTap: () {
+                final link = ZagLinkedContent.rottenTomatoes(widget.movie?.title);
+                if (link != null) link.openLink();
+              },
             ),
           if (_ratings?.metacritic != null)
             _buildRating(

--- a/zagreus/lib/utils/links.dart
+++ b/zagreus/lib/utils/links.dart
@@ -130,6 +130,15 @@ enum ZagLinkedContent {
     }
   }
 
+  static String? rottenTomatoes(String? title) {
+    if (title == null || title.isEmpty) return null;
+    const base = 'https://www.rottentomatoes.com';
+
+    // URL encode the title for the search query
+    final encodedTitle = Uri.encodeComponent(title);
+    return '$base/search?search=$encodedTitle';
+  }
+
   static String? youtube(String? id) {
     if (id == null) return null;
     const base = 'https://www.youtube.com';


### PR DESCRIPTION
Implemented clickable Rotten Tomatoes ratings that open in the RT app:
- Added rottenTomatoes() helper that generates search URLs with movie title
- Made RT rating tile clickable with onTap handler
- Added 'rottentomatoes' to iOS LSApplicationQueriesSchemes

Uses search URL format (https://www.rottentomatoes.com/search?search={title}) since RT no longer supports direct IMDB ID lookups. RT supports universal links for all paths (/*), so search URLs will open in the app when installed.