### PR TITLE
Improve Rotten Tomatoes deep linking to use direct URLs

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -146,7 +146,10 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
               ),
               _ratings!.rottenTomatoes!,
               onTap: () {
-                final link = ZagLinkedContent.rottenTomatoes(widget.movie?.title);
+                final link = ZagLinkedContent.rottenTomatoes(
+                  widget.movie?.title,
+                  LinkedContentType.MOVIE,
+                );
                 if (link != null) link.openLink();
               },
             ),

--- a/zagreus/lib/utils/links.dart
+++ b/zagreus/lib/utils/links.dart
@@ -130,13 +130,27 @@ enum ZagLinkedContent {
     }
   }
 
-  static String? rottenTomatoes(String? title) {
+  static String? rottenTomatoes(String? title, LinkedContentType type) {
     if (title == null || title.isEmpty) return null;
     const base = 'https://www.rottentomatoes.com';
 
-    // URL encode the title for the search query
-    final encodedTitle = Uri.encodeComponent(title);
-    return '$base/search?search=$encodedTitle';
+    // Convert title to RT slug format:
+    // - Lowercase
+    // - Replace spaces with underscores
+    // - Keep alphanumeric and underscores only
+    final slug = title
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^\w\s]'), '') // Remove special chars
+        .replaceAll(RegExp(r'\s+'), '_'); // Replace spaces with underscores
+
+    switch (type) {
+      case LinkedContentType.MOVIE:
+        return '$base/m/$slug';
+      case LinkedContentType.SERIES:
+        return '$base/tv/$slug';
+      default:
+        throw UnsupportedError('$type content type is not supported');
+    }
   }
 
   static String? youtube(String? id) {


### PR DESCRIPTION
Changed RT links from search URLs to direct movie/TV show pages:
- Movies: https://www.rottentomatoes.com/m/{slug}
- TV shows: https://www.rottentomatoes.com/tv/{slug}

Slug generation converts title to lowercase and replaces spaces with underscores, matching RT's URL format. This provides a better experience as it links directly to the page instead of search results.

RT only adds year suffixes for duplicate/less popular titles, so the basic slug format works for most content.