### PR TITLE
Add Rotten Tomatoes to Sonarr series links sheet

### DIFF
--- a/zagreus/lib/modules/sonarr/routes/series_details/sheets/links.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/sheets/links.dart
@@ -14,6 +14,8 @@ class LinksSheet extends ZagBottomModalSheet {
   @override
   Widget builder(BuildContext context) {
     final imdb = ZagLinkedContent.imdb(series.imdbId);
+    final rottenTomatoes =
+        ZagLinkedContent.rottenTomatoes(series.title, LinkedContentType.SERIES);
     final tvdb =
         ZagLinkedContent.theTVDB(series.tvdbId, LinkedContentType.SERIES);
     final trakt =
@@ -27,6 +29,12 @@ class LinksSheet extends ZagBottomModalSheet {
             title: 'IMDb',
             leading: const ZagIconButton(icon: ZagIcons.IMDB),
             onTap: imdb.openLink,
+          ),
+        if (rottenTomatoes != null)
+          ZagBlock(
+            title: 'Rotten Tomatoes',
+            leading: const ZagIconButton(icon: ZagIcons.LINK),
+            onTap: rottenTomatoes.openLink,
           ),
         if (tvdb != null)
           ZagBlock(


### PR DESCRIPTION
Added Rotten Tomatoes link to TV show details page, positioned under IMDb:
- Generates RT TV show URL using slug format (/tv/{slug})
- Uses generic link icon since RT doesn't have a dedicated icon
- Provides direct deep linking to RT app when installed

This completes RT deep linking support for both movies and TV shows.