### PR TITLE
Add retry mechanism for deep links

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -145,12 +145,17 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
                 height: 20,
               ),
               _ratings!.rottenTomatoes!,
-              onTap: () {
+              onTap: () async {
                 final link = ZagLinkedContent.rottenTomatoes(
                   widget.movie?.title,
                   LinkedContentType.MOVIE,
                 );
-                if (link != null) link.openLink();
+                if (link != null) {
+                  link.openLink();
+                  // Retry after 2 seconds to handle cases where first tap doesn't work
+                  await Future.delayed(const Duration(seconds: 2));
+                  link.openLink();
+                }
               },
             ),
           if (_ratings?.metacritic != null)

--- a/zagreus/lib/modules/sonarr/routes/series_details/sheets/links.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/sheets/links.dart
@@ -34,7 +34,12 @@ class LinksSheet extends ZagBottomModalSheet {
           ZagBlock(
             title: 'Rotten Tomatoes',
             leading: const ZagIconButton(icon: ZagIcons.LINK),
-            onTap: rottenTomatoes.openLink,
+            onTap: () async {
+              rottenTomatoes.openLink();
+              // Retry after 2 seconds to handle cases where first tap doesn't work
+              await Future.delayed(const Duration(seconds: 2));
+              rottenTomatoes.openLink();
+            },
           ),
         if (tvdb != null)
           ZagBlock(


### PR DESCRIPTION
Implemented automatic retry for RT links to handle cases where the first tap doesn't successfully open the app:
- First attempt opens the link immediately
- Second attempt after 2-second delay
- Applied to both movie ratings tile and TV show links sheet

This addresses the common issue where RT deep links require multiple taps to successfully open in the app.