### PR TITLE
Reduce Rotten Tomatoes retry delay to 250ms

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -152,8 +152,8 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
                 );
                 if (link != null) {
                   link.openLink();
-                  // Retry after 2 seconds to handle cases where first tap doesn't work
-                  await Future.delayed(const Duration(seconds: 2));
+                  // Quick retry after 250ms to handle cases where first tap doesn't work
+                  await Future.delayed(const Duration(milliseconds: 250));
                   link.openLink();
                 }
               },

--- a/zagreus/lib/modules/sonarr/routes/series_details/sheets/links.dart
+++ b/zagreus/lib/modules/sonarr/routes/series_details/sheets/links.dart
@@ -36,8 +36,8 @@ class LinksSheet extends ZagBottomModalSheet {
             leading: const ZagIconButton(icon: ZagIcons.LINK),
             onTap: () async {
               rottenTomatoes.openLink();
-              // Retry after 2 seconds to handle cases where first tap doesn't work
-              await Future.delayed(const Duration(seconds: 2));
+              // Quick retry after 250ms to handle cases where first tap doesn't work
+              await Future.delayed(const Duration(milliseconds: 250));
               rottenTomatoes.openLink();
             },
           ),


### PR DESCRIPTION
Changed RT deep link retry from 2 seconds to 250 milliseconds to:
- Provide quicker response when first tap doesn't work
- Avoid triggering in-app browser on second attempt
- Make the retry feel more seamless to users

Applied to both movie ratings tile and TV show links sheet.