### PR TITLE
Update RT and Metacritic icons with conditional logic

### DIFF
--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/rotten_tomatoes_tile.dart
@@ -141,7 +141,7 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
           if (_ratings?.rottenTomatoes != null)
             _buildRating(
               Image.asset(
-                'assets/icons/ratings/rotten_tomatoes.png',
+                _getRottenTomatoesIcon(_ratings!.rottenTomatoes!),
                 height: 20,
               ),
               _ratings!.rottenTomatoes!,
@@ -155,19 +155,28 @@ class _RadarrRottenTomatoesTileState extends State<RadarrRottenTomatoesTile> {
             ),
           if (_ratings?.metacritic != null)
             _buildRating(
-              ClipOval(
-                child: Image.asset(
-                  'assets/icons/ratings/metacritic.jpg',
-                  height: 20,
-                  width: 20,
-                  fit: BoxFit.cover,
-                ),
+              Image.asset(
+                'assets/icons/ratings/metacritic-30.png',
+                height: 20,
               ),
               _ratings!.metacritic!,
             ),
         ],
       ),
     );
+  }
+
+  String _getRottenTomatoesIcon(String rating) {
+    // Parse the percentage from the rating string (e.g., "85%" -> 85)
+    final percentStr = rating.replaceAll('%', '').trim();
+    final percent = int.tryParse(percentStr) ?? 0;
+
+    // Show fresh tomato if 60% or higher, rotten if lower
+    if (percent >= 60) {
+      return 'assets/icons/ratings/rt-fresh-30.png';
+    } else {
+      return 'assets/icons/ratings/rt-rotten-30.png';
+    }
   }
 
   Widget _buildRating(Widget icon, String value, {VoidCallback? onTap}) {


### PR DESCRIPTION
Implemented dynamic Rotten Tomatoes icon selection:
- Shows fresh tomato (rt-fresh-30.png) for ratings 60% and above
- Shows rotten tomato (rt-rotten-30.png) for ratings below 60%
- Added _getRottenTomatoesIcon() helper to parse rating percentage

Updated Metacritic to use new metacritic-30.png icon and simplified the widget (removed ClipOval wrapper).

This provides better visual feedback for RT scores and uses the new icon assets.