### PR TITLE
Change movie detail blocks to open YouTube trailers on long press

### DIFF
--- a/zagreus/lib/modules/radarr/routes/add_movie/widgets/search_results_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie/widgets/search_results_tile.dart
@@ -102,5 +102,5 @@ class _State extends State<RadarrAddMovieSearchResultTile> {
   }
 
   Future<void>? _onLongPress() async =>
-      widget.movie.tmdbId?.toString().openTmdbMovie();
+      widget.movie.youTubeTrailerId?.openYouTube();
 }

--- a/zagreus/lib/modules/radarr/routes/movie_details/widgets/overview_movie_description_tile.dart
+++ b/zagreus/lib/modules/radarr/routes/movie_details/widgets/overview_movie_description_tile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/core.dart';
+import 'package:zagreus/extensions/string/links.dart';
 import 'package:zagreus/modules/radarr.dart';
 
 class RadarrMovieDetailsOverviewDescriptionTile extends StatelessWidget {
@@ -28,6 +29,7 @@ class RadarrMovieDetailsOverviewDescriptionTile extends StatelessWidget {
       customBodyMaxLines: 3,
       onTap: () async =>
           ZagDialogs().textPreview(context, movie!.title, movie!.overview!),
+      onLongPress: () async => movie!.youTubeTrailerId?.openYouTube(),
     );
   }
 }


### PR DESCRIPTION
Updated long press behavior on movie blocks to open YouTube trailers instead of TMDB pages. This applies to both the add movie search results and movie details overview tiles.