### PR TITLE
Add deep linking support for streaming providers

### DIFF
--- a/zagreus/lib/modules/discover/core/tmdb_api.dart
+++ b/zagreus/lib/modules/discover/core/tmdb_api.dart
@@ -689,8 +689,8 @@ class TMDBApi {
   }
 
   /// Get watch providers (streaming services) for a movie
-  /// Returns a map with 'streaming' and 'buyRent' lists of providers
-  static Future<Map<String, List<Map<String, dynamic>>>> getMovieWatchProviders(
+  /// Returns a map with 'streaming' and 'buyRent' lists of providers, plus a 'link' to JustWatch
+  static Future<Map<String, dynamic>> getMovieWatchProviders(
     int tmdbId, {
     required String region,
   }) async {
@@ -704,15 +704,18 @@ class TMDBApi {
         final results = data['results'] as Map<String, dynamic>?;
 
         if (results == null || results.isEmpty) {
-          return {'streaming': [], 'buyRent': []};
+          return {'streaming': [], 'buyRent': [], 'link': null};
         }
 
         final regionKey = region.toUpperCase();
         final regionData = results[regionKey] as Map<String, dynamic>?;
 
         if (regionData == null) {
-          return {'streaming': [], 'buyRent': []};
+          return {'streaming': [], 'buyRent': [], 'link': null};
         }
+
+        // Get the JustWatch link
+        final link = regionData['link'] as String?;
 
         // Get streaming providers (flatrate)
         final streamingProviders = (regionData['flatrate'] as List?)
@@ -760,18 +763,19 @@ class TMDBApi {
         return {
           'streaming': streamingProviders,
           'buyRent': buyRentProviders,
+          'link': link,
         };
       }
     } catch (e) {
       print('Error fetching movie watch providers: $e');
     }
 
-    return {'streaming': [], 'buyRent': []};
+    return {'streaming': [], 'buyRent': [], 'link': null};
   }
 
   /// Get watch providers (streaming services) for a TV show
-  /// Returns a map with 'streaming' and 'buyRent' lists of providers
-  static Future<Map<String, List<Map<String, dynamic>>>> getTVShowWatchProviders(
+  /// Returns a map with 'streaming' and 'buyRent' lists of providers, plus a 'link' to JustWatch
+  static Future<Map<String, dynamic>> getTVShowWatchProviders(
     int tmdbId, {
     required String region,
   }) async {
@@ -785,15 +789,18 @@ class TMDBApi {
         final results = data['results'] as Map<String, dynamic>?;
 
         if (results == null || results.isEmpty) {
-          return {'streaming': [], 'buyRent': []};
+          return {'streaming': [], 'buyRent': [], 'link': null};
         }
 
         final regionKey = region.toUpperCase();
         final regionData = results[regionKey] as Map<String, dynamic>?;
 
         if (regionData == null) {
-          return {'streaming': [], 'buyRent': []};
+          return {'streaming': [], 'buyRent': [], 'link': null};
         }
+
+        // Get the JustWatch link
+        final link = regionData['link'] as String?;
 
         // Get streaming providers (flatrate)
         final streamingProviders = (regionData['flatrate'] as List?)
@@ -841,13 +848,75 @@ class TMDBApi {
         return {
           'streaming': streamingProviders,
           'buyRent': buyRentProviders,
+          'link': link,
         };
       }
     } catch (e) {
       print('Error fetching TV show watch providers: $e');
     }
 
-    return {'streaming': [], 'buyRent': []};
+    return {'streaming': [], 'buyRent': [], 'link': null};
+  }
+
+  /// Build a deep link URL for a specific streaming provider
+  /// Returns the provider's app deep link or web URL based on provider_id
+  static String? buildProviderDeepLink({
+    required int providerId,
+    required String providerName,
+    required int tmdbId,
+    required String title,
+    required String mediaType, // 'movie' or 'tv'
+    String? fallbackLink,
+  }) {
+    // Provider IDs from TMDB (common ones):
+    // Netflix: 8
+    // Amazon Prime Video: 9, 119 (Prime Video, Amazon Video)
+    // Disney Plus: 337
+    // HBO Max: 384
+    // Hulu: 15
+    // Apple TV Plus: 350
+    // Paramount Plus: 531
+
+    switch (providerId) {
+      case 8: // Netflix
+        // Netflix deep link: nflx://www.netflix.com/title/search?q={title}
+        // We use search since we don't have Netflix IDs
+        final encodedTitle = Uri.encodeComponent(title);
+        return 'nflx://www.netflix.com/search?q=$encodedTitle';
+
+      case 9: // Amazon Prime Video
+      case 119: // Amazon Video
+        // Amazon deep link for Prime Video
+        final encodedTitle = Uri.encodeComponent(title);
+        return 'aiv://webapi/search?searchPhrase=$encodedTitle';
+
+      case 337: // Disney Plus
+        // Disney+ search - note: requires exact content ID for direct links
+        final encodedTitle = Uri.encodeComponent(title);
+        return 'disneyplus://search/$encodedTitle';
+
+      case 15: // Hulu
+        final encodedTitle = Uri.encodeComponent(title);
+        return 'hulu://search?query=$encodedTitle';
+
+      case 350: // Apple TV Plus
+        // Apple TV deep link
+        final encodedTitle = Uri.encodeComponent(title);
+        return 'videos://search?term=$encodedTitle';
+
+      case 384: // HBO Max
+      case 1899: // Max
+        final encodedTitle = Uri.encodeComponent(title);
+        return 'max://search?query=$encodedTitle';
+
+      case 531: // Paramount Plus
+        final encodedTitle = Uri.encodeComponent(title);
+        return 'paramount://search?q=$encodedTitle';
+
+      default:
+        // For unknown providers, use the fallback JustWatch link
+        return fallbackLink;
+    }
   }
 
   static String? _extractYear(String? dateString) {

--- a/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:zagreus/modules/discover/core/tmdb_api.dart';
 import 'package:zagreus/modules/radarr.dart';
 import 'package:zagreus/services/subscription_service.dart';
@@ -20,6 +21,7 @@ class _RadarrAddMovieStreamingProvidersTileState
     extends State<RadarrAddMovieStreamingProvidersTile> {
   List<Map<String, dynamic>> _streamingProviders = [];
   List<Map<String, dynamic>> _buyRentProviders = [];
+  String? _fallbackLink;
   bool _loading = true;
   bool _hasError = false;
   late final bool _isPremium;
@@ -61,6 +63,7 @@ class _RadarrAddMovieStreamingProvidersTileState
       setState(() {
         _streamingProviders = results['streaming'] ?? [];
         _buyRentProviders = results['buyRent'] ?? [];
+        _fallbackLink = results['link'] as String?;
         _loading = false;
       });
     } catch (e) {
@@ -163,16 +166,19 @@ class _RadarrAddMovieStreamingProvidersTileState
                       return const SizedBox.shrink();
                     }
 
-                    return Tooltip(
-                      message: provider['provider_name'] ?? '',
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(6),
-                        child: Image.network(
-                          TMDBApi.getImageUrl(logoPath, size: 'w92'),
-                          width: 32,
-                          height: 32,
-                          fit: BoxFit.cover,
-                          errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                    return GestureDetector(
+                      onTap: () => _openProvider(provider),
+                      child: Tooltip(
+                        message: provider['provider_name'] ?? '',
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(6),
+                          child: Image.network(
+                            TMDBApi.getImageUrl(logoPath, size: 'w92'),
+                            width: 32,
+                            height: 32,
+                            fit: BoxFit.cover,
+                            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                          ),
                         ),
                       ),
                     );
@@ -199,5 +205,82 @@ class _RadarrAddMovieStreamingProvidersTileState
         behavior: SnackBarBehavior.floating,
       ),
     );
+  }
+
+  Future<void> _openProvider(Map<String, dynamic> provider) async {
+    final movie = widget.movie;
+    if (movie == null) return;
+
+    final providerId = provider['provider_id'] as int;
+    final providerName = provider['provider_name'] as String? ?? 'Unknown';
+    final title = movie.title;
+    final tmdbId = movie.tmdbId;
+
+    if (tmdbId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Unable to open $providerName: Missing TMDB ID'),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    // Build deep link for this provider
+    final deepLink = TMDBApi.buildProviderDeepLink(
+      providerId: providerId,
+      providerName: providerName,
+      tmdbId: tmdbId,
+      title: title,
+      mediaType: 'movie',
+      fallbackLink: _fallbackLink,
+    );
+
+    if (deepLink == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('No link available for $providerName'),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    try {
+      final uri = Uri.parse(deepLink);
+      final canLaunch = await canLaunchUrl(uri);
+
+      if (canLaunch) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      } else {
+        // If deep link fails, try the fallback link
+        if (_fallbackLink != null) {
+          final fallbackUri = Uri.parse(_fallbackLink!);
+          await launchUrl(fallbackUri, mode: LaunchMode.externalApplication);
+        } else {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Unable to open $providerName'),
+                duration: const Duration(seconds: 2),
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+          }
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error opening $providerName: $e'),
+            duration: const Duration(seconds: 2),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
   }
 }

--- a/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:zagreus/modules/discover/core/tmdb_api.dart';
 import 'package:zagreus/modules/sonarr.dart';
 import 'package:zagreus/services/subscription_service.dart';
@@ -20,6 +21,7 @@ class _SonarrAddSeriesStreamingProvidersTileState
     extends State<SonarrAddSeriesStreamingProvidersTile> {
   List<Map<String, dynamic>> _streamingProviders = [];
   List<Map<String, dynamic>> _buyRentProviders = [];
+  String? _fallbackLink;
   bool _loading = true;
   bool _hasError = false;
   late final bool _isPremium;
@@ -70,6 +72,7 @@ class _SonarrAddSeriesStreamingProvidersTileState
       setState(() {
         _streamingProviders = results['streaming'] ?? [];
         _buyRentProviders = results['buyRent'] ?? [];
+        _fallbackLink = results['link'] as String?;
         _loading = false;
       });
     } catch (e) {
@@ -172,16 +175,19 @@ class _SonarrAddSeriesStreamingProvidersTileState
                       return const SizedBox.shrink();
                     }
 
-                    return Tooltip(
-                      message: provider['provider_name'] ?? '',
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(6),
-                        child: Image.network(
-                          TMDBApi.getImageUrl(logoPath, size: 'w92'),
-                          width: 32,
-                          height: 32,
-                          fit: BoxFit.cover,
-                          errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                    return GestureDetector(
+                      onTap: () => _openProvider(provider),
+                      child: Tooltip(
+                        message: provider['provider_name'] ?? '',
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(6),
+                          child: Image.network(
+                            TMDBApi.getImageUrl(logoPath, size: 'w92'),
+                            width: 32,
+                            height: 32,
+                            fit: BoxFit.cover,
+                            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                          ),
                         ),
                       ),
                     );
@@ -208,5 +214,92 @@ class _SonarrAddSeriesStreamingProvidersTileState
         behavior: SnackBarBehavior.floating,
       ),
     );
+  }
+
+  Future<void> _openProvider(Map<String, dynamic> provider) async {
+    final series = widget.series;
+    if (series == null) return;
+
+    final providerId = provider['provider_id'] as int;
+    final providerName = provider['provider_name'] as String? ?? 'Unknown';
+    final title = series.title;
+    final imdbId = series.imdbId;
+
+    // For TV shows we need to look up TMDB ID from IMDb ID
+    int? tmdbId;
+    try {
+      if (imdbId != null) {
+        tmdbId = await TMDBApi.getTmdbIdFromImdb(imdbId);
+      }
+    } catch (e) {
+      // Failed to get TMDB ID
+    }
+
+    if (tmdbId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Unable to open $providerName: Missing TMDB ID'),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    // Build deep link for this provider
+    final deepLink = TMDBApi.buildProviderDeepLink(
+      providerId: providerId,
+      providerName: providerName,
+      tmdbId: tmdbId,
+      title: title,
+      mediaType: 'tv',
+      fallbackLink: _fallbackLink,
+    );
+
+    if (deepLink == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('No link available for $providerName'),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    try {
+      final uri = Uri.parse(deepLink);
+      final canLaunch = await canLaunchUrl(uri);
+
+      if (canLaunch) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      } else {
+        // If deep link fails, try the fallback link
+        if (_fallbackLink != null) {
+          final fallbackUri = Uri.parse(_fallbackLink!);
+          await launchUrl(fallbackUri, mode: LaunchMode.externalApplication);
+        } else {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Unable to open $providerName'),
+                duration: const Duration(seconds: 2),
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+          }
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error opening $providerName: $e'),
+            duration: const Duration(seconds: 2),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
- Capture TMDB JustWatch link URLs from watch providers API
- Add buildProviderDeepLink() method supporting Netflix, Prime Video, Disney+, Hulu, Apple TV+, HBO Max, and Paramount+
- Make streaming provider icons tappable in both Movie and TV Show details
- Implement URL launching with deep link fallback to JustWatch
- Netflix deep link opens search in app: nflx://www.netflix.com/search?q={title}