### PR TITLE
Fix: Ensure streaming provider deep links open apps directly

### DIFF
--- a/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
@@ -261,15 +261,16 @@ class _RadarrAddMovieStreamingProvidersTileState
 
     try {
       final uri = Uri.parse(deepLink);
-      final canLaunch = await canLaunchUrl(uri);
 
-      if (canLaunch) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      } else {
-        // If deep link fails, try the fallback link
+      // Try to launch the deep link directly
+      // Using mode: LaunchMode.externalApplication for app deep links
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+
+      if (!launched) {
+        // If deep link fails, try the fallback JustWatch link in an in-app browser
         if (_fallbackLink != null) {
           final fallbackUri = Uri.parse(_fallbackLink!);
-          await launchUrl(fallbackUri, mode: LaunchMode.externalApplication);
+          await launchUrl(fallbackUri, mode: LaunchMode.inAppWebView);
         } else {
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
@@ -283,14 +284,32 @@ class _RadarrAddMovieStreamingProvidersTileState
         }
       }
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Error opening $providerName: $e'),
-            duration: const Duration(seconds: 2),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
+      // If deep link throws an exception, try the fallback JustWatch link
+      if (_fallbackLink != null) {
+        try {
+          final fallbackUri = Uri.parse(_fallbackLink!);
+          await launchUrl(fallbackUri, mode: LaunchMode.inAppWebView);
+        } catch (fallbackError) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Error opening link: $fallbackError'),
+                duration: const Duration(seconds: 2),
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+          }
+        }
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Error opening $providerName: $e'),
+              duration: const Duration(seconds: 2),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        }
       }
     }
   }

--- a/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
@@ -280,15 +280,16 @@ class _SonarrAddSeriesStreamingProvidersTileState
 
     try {
       final uri = Uri.parse(deepLink);
-      final canLaunch = await canLaunchUrl(uri);
 
-      if (canLaunch) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      } else {
-        // If deep link fails, try the fallback link
+      // Try to launch the deep link directly
+      // Using mode: LaunchMode.externalApplication for app deep links
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+
+      if (!launched) {
+        // If deep link fails, try the fallback JustWatch link in an in-app browser
         if (_fallbackLink != null) {
           final fallbackUri = Uri.parse(_fallbackLink!);
-          await launchUrl(fallbackUri, mode: LaunchMode.externalApplication);
+          await launchUrl(fallbackUri, mode: LaunchMode.inAppWebView);
         } else {
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
@@ -302,14 +303,32 @@ class _SonarrAddSeriesStreamingProvidersTileState
         }
       }
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Error opening $providerName: $e'),
-            duration: const Duration(seconds: 2),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
+      // If deep link throws an exception, try the fallback JustWatch link
+      if (_fallbackLink != null) {
+        try {
+          final fallbackUri = Uri.parse(_fallbackLink!);
+          await launchUrl(fallbackUri, mode: LaunchMode.inAppWebView);
+        } catch (fallbackError) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Error opening link: $fallbackError'),
+                duration: const Duration(seconds: 2),
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+          }
+        }
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Error opening $providerName: $e'),
+              duration: const Duration(seconds: 2),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
Changes:
- Remove canLaunchUrl check that was preventing deep links from working
- Try to launch app deep links directly instead of checking first
- Open JustWatch fallback in in-app browser instead of externally
- Add better error handling with fallback to JustWatch on failure

This fixes the issue where clicking Netflix would open JustWatch instead of the Netflix app, and ensures fallback links open in-app.