### PR TITLE
Fix: Open JustWatch links in-app and improve Netflix deep linking

### DIFF
--- a/zagreus/lib/modules/discover/core/tmdb_api.dart
+++ b/zagreus/lib/modules/discover/core/tmdb_api.dart
@@ -879,10 +879,10 @@ class TMDBApi {
 
     switch (providerId) {
       case 8: // Netflix
-        // Netflix deep link: nflx://www.netflix.com/title/search?q={title}
-        // We use search since we don't have Netflix IDs
+        // Netflix web URL - will open in app if installed, otherwise in browser
+        // We use search since we don't have Netflix internal content IDs
         final encodedTitle = Uri.encodeComponent(title);
-        return 'nflx://www.netflix.com/search?q=$encodedTitle';
+        return 'https://www.netflix.com/search?q=$encodedTitle';
 
       case 9: // Amazon Prime Video
       case 119: // Amazon Video

--- a/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
@@ -262,9 +262,12 @@ class _RadarrAddMovieStreamingProvidersTileState
     try {
       final uri = Uri.parse(deepLink);
 
-      // Try to launch the deep link directly
-      // Using mode: LaunchMode.externalApplication for app deep links
-      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      // Determine the launch mode based on the URL scheme
+      // Web URLs (http/https) should open in-app, app deep links (nflx://, etc.) should open externally
+      final isWebUrl = uri.scheme == 'http' || uri.scheme == 'https';
+      final mode = isWebUrl ? LaunchMode.inAppWebView : LaunchMode.externalApplication;
+
+      final launched = await launchUrl(uri, mode: mode);
 
       if (!launched) {
         // If deep link fails, try the fallback JustWatch link in an in-app browser

--- a/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
@@ -281,9 +281,12 @@ class _SonarrAddSeriesStreamingProvidersTileState
     try {
       final uri = Uri.parse(deepLink);
 
-      // Try to launch the deep link directly
-      // Using mode: LaunchMode.externalApplication for app deep links
-      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      // Determine the launch mode based on the URL scheme
+      // Web URLs (http/https) should open in-app, app deep links (nflx://, etc.) should open externally
+      final isWebUrl = uri.scheme == 'http' || uri.scheme == 'https';
+      final mode = isWebUrl ? LaunchMode.inAppWebView : LaunchMode.externalApplication;
+
+      final launched = await launchUrl(uri, mode: mode);
 
       if (!launched) {
         // If deep link fails, try the fallback JustWatch link in an in-app browser


### PR DESCRIPTION
- JustWatch links now open in in-app browser instead of Safari
- Web URLs (http/https) automatically use in-app browser mode
- App deep links (nflx://, etc.) continue to open in external apps
- Netflix now uses web URL for better app integration