### PR TITLE
Fix: Open Netflix and streaming provider URLs externally to launch apps

### DIFF
--- a/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
@@ -262,12 +262,10 @@ class _RadarrAddMovieStreamingProvidersTileState
     try {
       final uri = Uri.parse(deepLink);
 
-      // Determine the launch mode based on the URL scheme
-      // Web URLs (http/https) should open in-app, app deep links (nflx://, etc.) should open externally
-      final isWebUrl = uri.scheme == 'http' || uri.scheme == 'https';
-      final mode = isWebUrl ? LaunchMode.inAppWebView : LaunchMode.externalApplication;
-
-      final launched = await launchUrl(uri, mode: mode);
+      // Always open streaming provider links externally so:
+      // 1. App deep links (nflx://, aiv://, etc.) can launch the apps
+      // 2. Web URLs (netflix.com, etc.) can redirect to apps or open in user's browser where they're logged in
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
 
       if (!launched) {
         // If deep link fails, try the fallback JustWatch link in an in-app browser

--- a/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
@@ -281,12 +281,10 @@ class _SonarrAddSeriesStreamingProvidersTileState
     try {
       final uri = Uri.parse(deepLink);
 
-      // Determine the launch mode based on the URL scheme
-      // Web URLs (http/https) should open in-app, app deep links (nflx://, etc.) should open externally
-      final isWebUrl = uri.scheme == 'http' || uri.scheme == 'https';
-      final mode = isWebUrl ? LaunchMode.inAppWebView : LaunchMode.externalApplication;
-
-      final launched = await launchUrl(uri, mode: mode);
+      // Always open streaming provider links externally so:
+      // 1. App deep links (nflx://, aiv://, etc.) can launch the apps
+      // 2. Web URLs (netflix.com, etc.) can redirect to apps or open in user's browser where they're logged in
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
 
       if (!launched) {
         // If deep link fails, try the fallback JustWatch link in an in-app browser


### PR DESCRIPTION
Changes streaming provider links to always open externally instead of in-app browser. This allows:
- Netflix and other web URLs to properly redirect to their native apps if installed
- Users to access sites in their regular browser where they're already logged in
- App deep links (nflx://, aiv://, etc.) to work correctly

Previously, https:// URLs were opening in an in-app browser, which prevented app redirection and showed sign-in screens.