### PR TITLE
Add Pro check for Prowlarr search functionality

### DIFF
--- a/zagreus/lib/modules/prowlarr/routes/prowlarr_home.dart
+++ b/zagreus/lib/modules/prowlarr/routes/prowlarr_home.dart
@@ -4,6 +4,7 @@ import 'package:zagreus/api/prowlarr/models.dart';
 import 'package:zagreus/database/models/indexer.dart';
 import 'package:zagreus/modules/prowlarr/core.dart';
 import 'package:zagreus/core.dart';
+import 'package:zagreus/utils/zagreus_pro.dart';
 
 /// Prowlarr home page - main search interface
 class ProwlarrHomePage extends StatefulWidget {
@@ -74,6 +75,46 @@ class _ProwlarrHomePageState extends State<ProwlarrHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    // Check if user has Pro access
+    if (!ZagreusPro.isEnabled) {
+      return Scaffold(
+        key: _scaffoldKey,
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_rounded),
+            onPressed: () => Navigator.of(context).maybePop(),
+          ),
+          title: Text(widget.indexer.displayName),
+        ),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.star_rounded, size: 64, color: Colors.amber),
+                const SizedBox(height: 16),
+                Text(
+                  'zagreus.Pro'.tr(),
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'Prowlarr search is a Pro feature. Upgrade to Pro to search with Prowlarr.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 16),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
     return ChangeNotifierProvider<ProwlarrState>.value(
       value: _state,
       child: Scaffold(

--- a/zagreus/lib/modules/search/routes/indexers/widgets/indexer_tile.dart
+++ b/zagreus/lib/modules/search/routes/indexers/widgets/indexer_tile.dart
@@ -4,6 +4,7 @@ import 'package:zagreus/database/models/indexer.dart';
 import 'package:zagreus/modules/search.dart';
 import 'package:zagreus/router/routes/search.dart';
 import 'package:zagreus/modules/prowlarr/routes/prowlarr_home.dart';
+import 'package:zagreus/utils/zagreus_pro.dart';
 
 class SearchIndexerTile extends StatelessWidget {
   final ZagIndexer? indexer;
@@ -21,6 +22,15 @@ class SearchIndexerTile extends StatelessWidget {
       trailing: const ZagIconButton.arrow(),
       onTap: () async {
         if (indexer!.isProwlarr) {
+          // Prowlarr search requires Pro
+          if (!ZagreusPro.isEnabled) {
+            ZagDialogs().showOkDialog(
+              context: context,
+              title: 'zagreus.Pro'.tr(),
+              content: 'Prowlarr search is a Pro feature. Upgrade to Pro to search with Prowlarr.',
+            );
+            return;
+          }
           // Use the richer Prowlarr UI when the indexer is marked as Prowlarr
           Navigator.of(context).push(
             MaterialPageRoute(


### PR DESCRIPTION
Prevent users who drop from Pro from continuing to use Prowlarr search by adding Pro checks when accessing Prowlarr indexers. Shows a dialog when tapping a Prowlarr indexer and displays a Pro upgrade message if they access the page directly.