### PR TITLE
Comment out search history button in Prowlarr

### DIFF
--- a/zagreus/lib/modules/prowlarr/routes/prowlarr_home.dart
+++ b/zagreus/lib/modules/prowlarr/routes/prowlarr_home.dart
@@ -126,13 +126,13 @@ class _ProwlarrHomePageState extends State<ProwlarrHomePage> {
             onPressed: () => Navigator.of(context).maybePop(),
           ),
           title: Text(widget.indexer.displayName),
-          actions: [
-            IconButton(
-              icon: const Icon(Icons.history_rounded),
-              tooltip: 'Search History',
-              onPressed: _showSearchHistorySheet,
-            ),
-          ],
+          // actions: [
+          //   IconButton(
+          //     icon: const Icon(Icons.history_rounded),
+          //     tooltip: 'Search History',
+          //     onPressed: _showSearchHistorySheet,
+          //   ),
+          // ],
           bottom: PreferredSize(
             preferredSize: const Size.fromHeight(60),
             child: Padding(


### PR DESCRIPTION
Temporarily disabled the history button in the Prowlarr search interface by commenting out the actions section in the AppBar.