### PR TITLE
Add confirmation step for VM and Docker actions

### DIFF
--- a/zagreus/lib/database/tables/zagreus.dart
+++ b/zagreus/lib/database/tables/zagreus.dart
@@ -125,7 +125,8 @@ enum ZagreusDatabase<T> with ZagTableMixin<T> {
   DASHBOARD_SHOW_MODULES_TAB<bool>(true),
   DISCOVER_SHOW_MODULES_TAB<bool>(false),
   SHOW_CALENDAR_TAB<bool>(true),
-  SHOW_AGENT_TAB<bool>(true);
+  SHOW_AGENT_TAB<bool>(true),
+  UNRAID_CONFIRM_ACTIONS<bool>(true);
 
   @override
   ZagTable get table => ZagTable.zagreus;

--- a/zagreus/lib/modules/settings/routes/configuration_general/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_general/route.dart
@@ -213,6 +213,8 @@ class _State extends State<ConfigurationGeneralRoute>
       );
     }
 
+    widgets.add(_confirmUnraidActions());
+
     return widgets;
   }
 
@@ -352,6 +354,24 @@ class _State extends State<ConfigurationGeneralRoute>
             BIOSDatabase.BOOT_MODULE.update(result.item2!);
           }
         },
+      ),
+    );
+  }
+
+  Widget _confirmUnraidActions() {
+    const db = ZagreusDatabase.UNRAID_CONFIRM_ACTIONS;
+    return db.listenableBuilder(
+      builder: (context, _) => ZagBlock(
+        title: 'Confirm Unraid Actions',
+        body: const [
+          TextSpan(
+            text: 'Show confirmation dialog before starting, stopping, or rebooting VMs and Docker containers',
+          ),
+        ],
+        trailing: ZagSwitch(
+          value: db.read(),
+          onChanged: db.update,
+        ),
       ),
     );
   }

--- a/zagreus/lib/modules/unraid/routes/unraid/pages/docker.dart
+++ b/zagreus/lib/modules/unraid/routes/unraid/pages/docker.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:zagreus/core.dart';
+import 'package:zagreus/database/tables/zagreus.dart';
 import 'package:zagreus/modules/unraid.dart';
 import 'package:zagreus/api/unraid/unraid.dart';
 import 'package:zagreus/api/unraid/models.dart';
@@ -325,25 +326,58 @@ class _UnraidDockerPageState extends State<UnraidDockerPage>
     );
   }
 
+  Future<bool> _confirmDockerAction(UnraidDockerContainer container) async {
+    // Check if confirmations are enabled
+    final confirmEnabled = ZagreusDatabase.UNRAID_CONFIRM_ACTIONS.read();
+    if (!confirmEnabled) return true;
+
+    bool confirmed = false;
+
+    final actionLabel = container.isRunning ? 'stop' : 'start';
+    final actionColor = container.isRunning ? ZagColours.red : Colors.green;
+
+    await ZagDialog.dialog(
+      context: context,
+      title: 'Confirm Action',
+      buttons: [
+        ZagDialog.button(
+          text: actionLabel.substring(0, 1).toUpperCase() + actionLabel.substring(1),
+          textColor: actionColor,
+          onPressed: () {
+            confirmed = true;
+            Navigator.of(context, rootNavigator: true).pop();
+          },
+        ),
+      ],
+      content: [
+        ZagDialog.textContent(
+          text: 'Are you sure you want to $actionLabel ${container.name}?',
+        ),
+      ],
+      contentPadding: ZagDialog.textDialogContentPadding(),
+    );
+
+    return confirmed;
+  }
+
   Future<void> _handleToggleContainer(UnraidDockerContainer container) async {
+    final serverState = context.read<UnraidState>();
+    if (!serverState.isConfigured) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Configure your server connection first.'),
+        ),
+      );
+      return;
+    }
+
+    // Show confirmation dialog
+    final confirmed = await _confirmDockerAction(container);
+    if (!confirmed) return;
+
     setState(() {
       _processingContainers[container.id] = true;
     });
-
-    final serverState = context.read<UnraidState>();
-    if (!serverState.isConfigured) {
-      if (mounted) {
-        setState(() {
-          _processingContainers[container.id] = false;
-        });
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Configure your server connection first.'),
-          ),
-        );
-      }
-      return;
-    }
 
     final api = UnraidAPI(
       host: serverState.host,

--- a/zagreus/lib/modules/unraid/routes/unraid/pages/vms.dart
+++ b/zagreus/lib/modules/unraid/routes/unraid/pages/vms.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:zagreus/api/unraid/models.dart';
 import 'package:zagreus/api/unraid/unraid.dart';
 import 'package:zagreus/core.dart';
+import 'package:zagreus/database/tables/zagreus.dart';
 import 'package:zagreus/modules/unraid.dart';
 
 enum _VmAction {
@@ -315,6 +316,52 @@ class _UnraidVmPageState extends State<UnraidVmPage>
     );
   }
 
+  Future<bool> _confirmVmAction(
+    UnraidVirtualMachine vm,
+    _VmAction action,
+  ) async {
+    // Check if confirmations are enabled
+    final confirmEnabled = ZagreusDatabase.UNRAID_CONFIRM_ACTIONS.read();
+    if (!confirmEnabled) return true;
+
+    bool confirmed = false;
+
+    final actionLabel = switch (action) {
+      _VmAction.start => 'start',
+      _VmAction.stop => 'stop',
+      _VmAction.reboot => 'reboot',
+    };
+
+    final actionColor = switch (action) {
+      _VmAction.start => Colors.green,
+      _VmAction.stop => ZagColours.red,
+      _VmAction.reboot => ZagColours.orange,
+    };
+
+    await ZagDialog.dialog(
+      context: context,
+      title: 'Confirm Action',
+      buttons: [
+        ZagDialog.button(
+          text: actionLabel.substring(0, 1).toUpperCase() + actionLabel.substring(1),
+          textColor: actionColor,
+          onPressed: () {
+            confirmed = true;
+            Navigator.of(context, rootNavigator: true).pop();
+          },
+        ),
+      ],
+      content: [
+        ZagDialog.textContent(
+          text: 'Are you sure you want to $actionLabel ${vm.name}?',
+        ),
+      ],
+      contentPadding: ZagDialog.textDialogContentPadding(),
+    );
+
+    return confirmed;
+  }
+
   Future<void> _handleVmAction(
     UnraidVirtualMachine vm,
     _VmAction action,
@@ -328,6 +375,10 @@ class _UnraidVmPageState extends State<UnraidVmPage>
       );
       return;
     }
+
+    // Show confirmation dialog
+    final confirmed = await _confirmVmAction(vm, action);
+    if (!confirmed) return;
 
     setState(() {
       _pendingActions[vm.id] = action;


### PR DESCRIPTION
- Added UNRAID_CONFIRM_ACTIONS setting to enable/disable confirmations
- Added toggle in Settings > Config > General for action confirmations
- Implemented confirmation dialogs for VM actions (start, stop, reboot)
- Implemented confirmation dialogs for Docker container actions (start, stop)
- Confirmations can be disabled via settings (default: enabled)
- Dialog buttons are color-coded to match action type (green for start, red for stop, orange for reboot)