### PR TITLE
Fix import path after UIPreferencesDatabase rename

### DIFF
--- a/zagreus/lib/modules/unraid/core.dart
+++ b/zagreus/lib/modules/unraid/core.dart
@@ -1,2 +1,2 @@
-export 'package:zagreus/database/tables/unraid.dart';
+export 'package:zagreus/database/tables/ui_preferences.dart';
 export 'core/state.dart';


### PR DESCRIPTION
Update unraid/core.dart to import the renamed ui_preferences.dart file instead of the old unraid.dart file that no longer exists.