### PR TITLE
Filter Prowlarr indexers for free users in search module

### DIFF
--- a/zagreus/lib/modules.dart
+++ b/zagreus/lib/modules.dart
@@ -20,6 +20,7 @@ import 'package:zagreus/modules/unraid.dart';
 import 'package:zagreus/modules/readarr.dart';
 import 'package:zagreus/modules/dashboard/core/state.dart';
 import 'package:zagreus/api/wake_on_lan/wake_on_lan.dart';
+import 'package:zagreus/utils/zagreus_pro.dart';
 
 part 'modules.g.dart';
 
@@ -160,7 +161,12 @@ extension ZagModuleEnablementExtension on ZagModule {
       case ZagModule.SABNZBD:
         return ZagProfile.current.sabnzbdEnabled;
       case ZagModule.SEARCH:
-        return !ZagBox.indexers.isEmpty;
+        // Search is enabled if there are indexers available to the user
+        // Free users can only access non-Prowlarr indexers
+        if (ZagBox.indexers.isEmpty) return false;
+        if (ZagreusPro.isEnabled) return true;
+        // For free users, check if there are any non-Prowlarr indexers
+        return ZagBox.indexers.data.any((indexer) => !indexer.isProwlarr);
       case ZagModule.SONARR:
         return ZagProfile.current.sonarrEnabled;
       case ZagModule.TAUTULLI:

--- a/zagreus/lib/modules/search/routes/indexers/route.dart
+++ b/zagreus/lib/modules/search/routes/indexers/route.dart
@@ -3,6 +3,7 @@ import 'package:zagreus/core.dart';
 import 'package:zagreus/modules/search.dart';
 import 'package:zagreus/router/routes/search.dart';
 import 'package:zagreus/widgets/sheets/download_client/button.dart';
+import 'package:zagreus/utils/zagreus_pro.dart';
 
 class SearchRoute extends StatefulWidget {
   const SearchRoute({
@@ -40,7 +41,15 @@ class _State extends State<SearchRoute> with ZagScrollControllerMixin {
   Widget _drawer() => ZagDrawer(page: ZagModule.SEARCH.key);
 
   Widget _body() {
-    if (ZagBox.indexers.isEmpty) {
+    // Filter out Prowlarr indexers for free users
+    final availableIndexers = ZagBox.indexers.data.where((indexer) {
+      if (indexer.isProwlarr && !ZagreusPro.isEnabled) {
+        return false;
+      }
+      return true;
+    }).toList();
+
+    if (availableIndexers.isEmpty) {
       return ZagMessage.moduleNotEnabled(
         context: context,
         module: ZagModule.SEARCH.title,
@@ -48,12 +57,12 @@ class _State extends State<SearchRoute> with ZagScrollControllerMixin {
     }
     return ZagListView(
       controller: scrollController,
-      children: _list,
+      children: _buildList(availableIndexers),
     );
   }
 
-  List<Widget> get _list {
-    final list = ZagBox.indexers.data
+  List<Widget> _buildList(List<dynamic> indexers) {
+    final list = indexers
         .map((indexer) => SearchIndexerTile(indexer: indexer))
         .toList();
     list.sort((a, b) => a.indexer!.displayName


### PR DESCRIPTION
Updated search module to properly handle free vs Pro users:
- Filter out Prowlarr indexers from the list for free users
- Update isEnabled check to only enable search if free users have non-Prowlarr indexers available
- Pro users continue to see all indexers including Prowlarr

This ensures free users can access search with regular indexers while Prowlarr remains a Pro-only feature.