### PR TITLE
Simplify search module gating for free users

### DIFF
--- a/zagreus/lib/modules.dart
+++ b/zagreus/lib/modules.dart
@@ -161,12 +161,9 @@ extension ZagModuleEnablementExtension on ZagModule {
       case ZagModule.SABNZBD:
         return ZagProfile.current.sabnzbdEnabled;
       case ZagModule.SEARCH:
-        // Search is enabled if there are indexers available to the user
-        // Free users can only access non-Prowlarr indexers
-        if (ZagBox.indexers.isEmpty) return false;
-        if (ZagreusPro.isEnabled) return true;
-        // For free users, check if there are any non-Prowlarr indexers
-        return ZagBox.indexers.data.any((indexer) => !indexer.isProwlarr);
+        // Search module is enabled if user has any indexers configured
+        // Filtering between Prowlarr and regular indexers happens in the UI
+        return !ZagBox.indexers.isEmpty;
       case ZagModule.SONARR:
         return ZagProfile.current.sonarrEnabled;
       case ZagModule.TAUTULLI:

--- a/zagreus/lib/modules/search/routes/indexers/route.dart
+++ b/zagreus/lib/modules/search/routes/indexers/route.dart
@@ -43,19 +43,29 @@ class _State extends State<SearchRoute> with ZagScrollControllerMixin {
   Widget _body() {
     return ZagBox.indexers.listenableBuilder(
       builder: (context, _) {
-        // Filter out Prowlarr indexers for free users
         final allIndexers = ZagBox.indexers.data.toList();
+
+        // Filter indexers based on Pro status
         final availableIndexers = allIndexers.where((indexer) {
-          // Free users: hide Prowlarr indexers
+          // Hide Prowlarr indexers for free users
           if (!ZagreusPro.isEnabled && indexer.isProwlarr) {
             return false;
           }
-          // Pro users: show all indexers
-          // Free users: show non-Prowlarr indexers
           return true;
         }).toList();
 
+        // Show message if no indexers available after filtering
         if (availableIndexers.isEmpty) {
+          final hasProwlarrOnly = allIndexers.isNotEmpty &&
+                                   allIndexers.every((i) => i.isProwlarr);
+
+          if (hasProwlarrOnly && !ZagreusPro.isEnabled) {
+            // User only has Prowlarr indexers but is on free tier
+            return ZagMessage(
+              text: 'Prowlarr search requires Zagreus Pro.\n\nAdd a regular indexer to use search, or upgrade to Pro for Prowlarr access.',
+            );
+          }
+
           return ZagMessage.moduleNotEnabled(
             context: context,
             module: ZagModule.SEARCH.title,


### PR DESCRIPTION
- Enable search module if ANY indexers exist (filtering in UI)
- Filter Prowlarr indexers in the UI for free users
- Show helpful message when only Prowlarr indexers exist on free tier
- Regular indexers now properly visible for free users