### PR TITLE
Fix calendar breaking when Lidarr has incorrect configuration

### DIFF
--- a/zagreus/lib/modules/dashboard/core/api/api.dart
+++ b/zagreus/lib/modules/dashboard/core/api/api.dart
@@ -7,6 +7,7 @@ import 'package:zagreus/modules/dashboard/core/api/data/abstract.dart';
 import 'package:zagreus/modules/dashboard/core/api/data/lidarr.dart';
 import 'package:zagreus/modules/dashboard/core/api/data/radarr.dart';
 import 'package:zagreus/modules/dashboard/core/api/data/sonarr.dart';
+import 'package:zagreus/system/logger.dart';
 import 'package:zagreus/widgets/ui.dart';
 import 'package:zagreus/vendor.dart';
 
@@ -33,14 +34,30 @@ class API {
     // Lidarr (no multi-instance support yet, always use main)
     if (profile.lidarrEnabled &&
         DashboardDatabase.CALENDAR_ENABLE_LIDARR.read()) {
-      await _getLidarrUpcoming(_upcoming, today, profile);
+      try {
+        await _getLidarrUpcoming(_upcoming, today, profile);
+      } catch (error, stack) {
+        ZagLogger().error(
+          'Failed to fetch Lidarr calendar data',
+          error,
+          stack,
+        );
+      }
     }
     
     // Radarr - check main and instances
     if (DashboardDatabase.CALENDAR_ENABLE_RADARR.read()) {
       // Main Radarr (null instanceKey = main)
       if (profile.radarrEnabled && (showAll || filter.contains('radarr:main'))) {
-        await _getRadarrUpcoming(_upcoming, today, profile);
+        try {
+          await _getRadarrUpcoming(_upcoming, today, profile);
+        } catch (error, stack) {
+          ZagLogger().error(
+            'Failed to fetch Radarr calendar data (main)',
+            error,
+            stack,
+          );
+        }
       }
       // Radarr instances
       final currentProfileKey = ZagreusDatabase.ENABLED_PROFILE.read();
@@ -49,7 +66,15 @@ class API {
         if (showAll || filter.contains('radarr:$instanceKey')) {
           final instanceProfile = ZagBox.profiles.read(instanceKey);
           if (instanceProfile != null && instanceProfile.radarrEnabled) {
-            await _getRadarrUpcoming(_upcoming, today, instanceProfile, instanceKey: instanceKey);
+            try {
+              await _getRadarrUpcoming(_upcoming, today, instanceProfile, instanceKey: instanceKey);
+            } catch (error, stack) {
+              ZagLogger().error(
+                'Failed to fetch Radarr calendar data (instance: $instanceKey)',
+                error,
+                stack,
+              );
+            }
           }
         }
       }
@@ -59,7 +84,15 @@ class API {
     if (DashboardDatabase.CALENDAR_ENABLE_SONARR.read()) {
       // Main Sonarr (null instanceKey = main)
       if (profile.sonarrEnabled && (showAll || filter.contains('sonarr:main'))) {
-        await _getSonarrUpcoming(_upcoming, today, profile);
+        try {
+          await _getSonarrUpcoming(_upcoming, today, profile);
+        } catch (error, stack) {
+          ZagLogger().error(
+            'Failed to fetch Sonarr calendar data (main)',
+            error,
+            stack,
+          );
+        }
       }
       // Sonarr instances
       final currentProfileKey = ZagreusDatabase.ENABLED_PROFILE.read();
@@ -68,7 +101,15 @@ class API {
         if (showAll || filter.contains('sonarr:$instanceKey')) {
           final instanceProfile = ZagBox.profiles.read(instanceKey);
           if (instanceProfile != null && instanceProfile.sonarrEnabled) {
-            await _getSonarrUpcoming(_upcoming, today, instanceProfile, instanceKey: instanceKey);
+            try {
+              await _getSonarrUpcoming(_upcoming, today, instanceProfile, instanceKey: instanceKey);
+            } catch (error, stack) {
+              ZagLogger().error(
+                'Failed to fetch Sonarr calendar data (instance: $instanceKey)',
+                error,
+                stack,
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
Previously, if Lidarr was enabled but had incorrect connection details, the entire calendar would fail with "an error occurred", even if Radarr and Sonarr were working correctly.

This change adds error handling around each service API call (Lidarr, Radarr, and Sonarr) so that failures in one service don't prevent the calendar from displaying data from working services. Errors are logged individually, allowing the calendar to show partial data.

Changes:
- Added try-catch blocks around all service API calls in getUpcoming()
- Added ZagLogger import for proper error logging
- Errors are logged with service-specific messages for easier debugging
- Calendar now shows data from working services even if others fail