### PR TITLE
Fix calendar scrolling performance on dashboard

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/route.dart
@@ -36,6 +36,7 @@ class _State extends State<DashboardRoute> {
   final _agentChatKey = GlobalKey<ZChatPageState>();
   ZagPageController? _pageController;
   bool _isAgentActive = false;
+  int? _currentPage;
 
   @override
   void initState() {
@@ -51,10 +52,19 @@ class _State extends State<DashboardRoute> {
     }
 
     _pageController = ZagPageController(initialPage: page);
+    _currentPage = page;
 
     // Add listener to rebuild app bar when page changes
+    // Only rebuild when the page index actually changes, not during animation
     _pageController?.addListener(() {
-      if (mounted) setState(() {});
+      if (mounted) {
+        final newPage = _pageController!.page?.round();
+        if (newPage != null && newPage != _currentPage) {
+          setState(() {
+            _currentPage = newPage;
+          });
+        }
+      }
     });
 
     // Inject global cube overlay


### PR DESCRIPTION
The calendar was experiencing janky scrolling because the PageController listener was firing continuously during swipe animations, causing excessive rebuilds of the widget tree (including FutureBuilder and all calendar widgets).

Changed the listener to only trigger setState when the page index actually changes (not on every animation frame), reducing rebuilds from dozens per second to just 1-2 per page transition.