### PR TITLE
Reduce JustWatch icon size in discover footer

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -2502,7 +2502,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
               _metadataIcon(
                 'assets/images/justwatch_long.png',
                 fullWidth: true,
-                height: 28,
+                height: 27,
               ),
             ],
           ),


### PR DESCRIPTION
Reduced JustWatch logo height from 28 to 27 pixels (~4% smaller) at the bottom of the discover tab for better visual balance.