### PR TITLE
Add custom headers to Overseerr integration

### DIFF
--- a/zagreus/lib/modules/settings/core/pages/headers.dart
+++ b/zagreus/lib/modules/settings/core/pages/headers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:zagreus/core.dart';
+import 'package:zagreus/modules/overseerr.dart';
 import 'package:zagreus/modules/radarr.dart';
 import 'package:zagreus/modules/readarr.dart';
 import 'package:zagreus/modules/sonarr.dart';
@@ -118,7 +119,7 @@ class _State extends State<SettingsHeaderRoute> with ZagScrollControllerMixin {
       case ZagModule.WAKE_ON_LAN:
         throw Exception('Wake on LAN does not have a headers page');
       case ZagModule.OVERSEERR:
-        throw Exception('Overseerr does not have a headers page');
+        return ZagProfile.current.overseerrHeaders;
       case ZagModule.TAUTULLI:
         return ZagProfile.current.tautulliHeaders;
       case ZagModule.UNRAID:
@@ -157,7 +158,7 @@ class _State extends State<SettingsHeaderRoute> with ZagScrollControllerMixin {
       case ZagModule.UNRAID:
         return context.read<UnraidState>().reset();
       case ZagModule.OVERSEERR:
-        return;
+        return context.read<OverseerrState>().reset();
       case ZagModule.DISCOVER:
         throw Exception('Discover does not have a global state');
       case ZagModule.READARR:

--- a/zagreus/lib/modules/settings/routes/configuration_overseerr/pages/connection_details.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_overseerr/pages/connection_details.dart
@@ -81,6 +81,7 @@ class _State extends State<ConfigurationOverseerrConnectionDetailsRoute>
   List<Widget> _remoteBlocks() => [
         _remoteHost(),
         _apiKey(),
+        _customHeaders(),
       ];
 
   List<Widget> _localBlocks() => [
@@ -233,6 +234,15 @@ class _State extends State<ConfigurationOverseerrConnectionDetailsRoute>
           context.read<OverseerrState>().reset();
         }
       },
+    );
+  }
+
+  Widget _customHeaders() {
+    return ZagBlock(
+      title: 'settings.CustomHeaders'.tr(),
+      body: [TextSpan(text: 'settings.CustomHeadersDescription'.tr())],
+      trailing: const ZagIconButton.arrow(),
+      onTap: SettingsRoutes.CONFIGURATION_OVERSEERR_CONNECTION_DETAILS_HEADERS.go,
     );
   }
 

--- a/zagreus/lib/modules/settings/routes/configuration_overseerr/pages/headers.dart
+++ b/zagreus/lib/modules/settings/routes/configuration_overseerr/pages/headers.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:zagreus/modules.dart';
+import 'package:zagreus/modules/settings.dart';
+
+class ConfigurationOverseerrConnectionDetailsHeadersRoute extends StatelessWidget {
+  const ConfigurationOverseerrConnectionDetailsHeadersRoute({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const SettingsHeaderRoute(module: ZagModule.OVERSEERR);
+  }
+}

--- a/zagreus/lib/router/routes/settings.dart
+++ b/zagreus/lib/router/routes/settings.dart
@@ -26,6 +26,7 @@ import 'package:zagreus/modules/settings/routes/configuration_nzbget/pages/defau
 import 'package:zagreus/modules/settings/routes/configuration_nzbget/pages/headers.dart';
 import 'package:zagreus/modules/settings/routes/configuration_nzbget/route.dart';
 import 'package:zagreus/modules/settings/routes/configuration_overseerr/pages/connection_details.dart';
+import 'package:zagreus/modules/settings/routes/configuration_overseerr/pages/headers.dart';
 import 'package:zagreus/modules/settings/routes/configuration_overseerr/route.dart';
 import 'package:zagreus/modules/settings/routes/configuration_quick_actions/route.dart';
 import 'package:zagreus/modules/settings/routes/configuration_radarr/pages/connection_details.dart';
@@ -100,6 +101,7 @@ enum SettingsRoutes with ZagRoutesMixin {
   CONFIGURATION_NZBGET_DEFAULT_PAGES('default_pages'),
   CONFIGURATION_OVERSEERR('overseerr'),
   CONFIGURATION_OVERSEERR_CONNECTION_DETAILS('connection_details'),
+  CONFIGURATION_OVERSEERR_CONNECTION_DETAILS_HEADERS('headers'),
   CONFIGURATION_QUICK_ACTIONS('quick_actions'),
   CONFIGURATION_RADARR('radarr'),
   CONFIGURATION_RADARR_CONNECTION_DETAILS('connection_details'),
@@ -216,6 +218,10 @@ enum SettingsRoutes with ZagRoutesMixin {
         return route(widget: const ConfigurationOverseerrRoute());
       case SettingsRoutes.CONFIGURATION_OVERSEERR_CONNECTION_DETAILS:
         return route(widget: const ConfigurationOverseerrConnectionDetailsRoute());
+      case SettingsRoutes.CONFIGURATION_OVERSEERR_CONNECTION_DETAILS_HEADERS:
+        return route(
+          widget: const ConfigurationOverseerrConnectionDetailsHeadersRoute(),
+        );
       case SettingsRoutes.CONFIGURATION_QUICK_ACTIONS:
         return route(widget: const ConfigurationQuickActionsRoute());
       case SettingsRoutes.CONFIGURATION_RADARR:
@@ -402,6 +408,10 @@ enum SettingsRoutes with ZagRoutesMixin {
       case SettingsRoutes.CONFIGURATION_OVERSEERR:
         return [
           SettingsRoutes.CONFIGURATION_OVERSEERR_CONNECTION_DETAILS.routes,
+        ];
+      case SettingsRoutes.CONFIGURATION_OVERSEERR_CONNECTION_DETAILS:
+        return [
+          SettingsRoutes.CONFIGURATION_OVERSEERR_CONNECTION_DETAILS_HEADERS.routes,
         ];
       case SettingsRoutes.CONFIGURATION_RADARR:
         return [


### PR DESCRIPTION
This commit adds UI support for custom headers in the Overseerr module, bringing it to feature parity with other integration modules like Radarr, Sonarr, and Tautulli.

Changes:
- Created headers.dart page for Overseerr settings UI
- Updated connection_details.dart to include custom headers navigation block
- Modified generic headers.dart to handle Overseerr module (return headers and reset state)
- Added CONFIGURATION_OVERSEERR_CONNECTION_DETAILS_HEADERS route to router
- Imported necessary headers page in settings router

The backend support for custom headers was already present in the Profile model (overseerrHeaders field) and OverseerrState (headers are passed to Dio client), so this change only adds the UI layer.