### PR TITLE
Fix slow hero carousel loading in dashboard

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -669,7 +669,7 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
     if (url == null || url.isEmpty) return;
     if (_precachedHeroBackdrops.contains(url)) return;
     _precachedHeroBackdrops.add(url);
-    precacheImage(NetworkImage(url), context);
+    precacheImage(CachedNetworkImageProvider(url), context);
   }
 
   Future<void> _loadRecentlyDownloaded({bool showGlobalLoader = true}) async {


### PR DESCRIPTION
… precaching

The carousel was updated to use CachedNetworkImage but the _precacheHeroImage method was still using NetworkImage for precaching. This created a cache mismatch where images were precached in Flutter's standard cache but CachedNetworkImage couldn't find them in its own cache, causing redundant fetches.

Updated _precacheHeroImage to use CachedNetworkImageProvider to ensure precaching uses the same cache as CachedNetworkImage, improving carousel loading performance.