### PR TITLE
Update search module icon to magnifying glass with earth

### DIFF
--- a/zagreus/lib/modules.dart
+++ b/zagreus/lib/modules.dart
@@ -224,7 +224,7 @@ extension ZagModuleMetadataExtension on ZagModule {
       case ZagModule.SABNZBD:
         return ZagIcons.SABNZBD;
       case ZagModule.SEARCH:
-        return Icons.search_rounded;
+        return Icons.travel_explore_rounded;
       case ZagModule.SETTINGS:
         return Icons.settings_rounded;
       case ZagModule.SONARR:


### PR DESCRIPTION
Changed the search module icon from a simple magnifying glass (search_rounded)
to a magnifying glass with earth (travel_explore_rounded) to better represent
global search functionality.