### PR TITLE
Set Z agent movie staging to fixed two columns

### DIFF
--- a/zagreus/lib/modules/discover/routes/z_assistant_results/route.dart
+++ b/zagreus/lib/modules/discover/routes/z_assistant_results/route.dart
@@ -278,10 +278,10 @@ class _ZAssistantResultsRouteState extends State<ZAssistantResultsRoute> with Za
     }
 
     final screenWidth = MediaQuery.sizeOf(context).width;
-    final savedColumns = ZagreusDatabase.DISCOVER_COLUMNS_PER_ROW.read() ?? 3;
-    final usesThreeColumns = savedColumns == 3;
-    final horizontalPadding = usesThreeColumns ? 20.0 : 16.0;
-    final gridSpacing = usesThreeColumns ? 16.0 : 12.0;
+    // Z Assistant always uses 2 columns, ignoring dashboard setting
+    const fixedColumns = 2;
+    const horizontalPadding = 16.0;
+    const gridSpacing = 12.0;
 
     return RefreshIndicator(
       onRefresh: _loadData,
@@ -292,8 +292,8 @@ class _ZAssistantResultsRouteState extends State<ZAssistantResultsRoute> with Za
           vertical: 20,
         ),
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: savedColumns,
-          childAspectRatio: 0.55,
+          crossAxisCount: fixedColumns,
+          childAspectRatio: 0.48, // Increased height to fit 8 lines of description
           crossAxisSpacing: gridSpacing,
           mainAxisSpacing: gridSpacing,
         ),
@@ -415,7 +415,7 @@ class _ZAssistantResultsRouteState extends State<ZAssistantResultsRoute> with Za
                   fontSize: 12,
                   color: Colors.grey[500],
                 ),
-                maxLines: 3,
+                maxLines: 8,
                 overflow: TextOverflow.ellipsis,
               ),
             ),


### PR DESCRIPTION
- Override dashboard columns setting to always use 2 columns in Z Assistant results
- Increase description maxLines from 3 to 8 for better content visibility
- Adjust container aspect ratio from 0.55 to 0.48 to accommodate taller descriptions