### PR TITLE
Fix phantom cube in streaming providers and navigation race condition

### DIFF
--- a/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/bottom_action_bar.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/bottom_action_bar.dart
@@ -41,7 +41,7 @@ class RadarrAddMovieDetailsActionBar extends StatelessWidget {
         searchForMovie: RadarrDatabase.ADD_MOVIE_SEARCH_FOR_MISSING.read(),
       )
           .then((movie) async {
-        context.read<RadarrState>().fetchMovies();
+        await context.read<RadarrState>().fetchMovies();
         context.read<RadarrAddMovieDetailsState>().movie.id = movie!.id;
         ZagRouter.router.pop();
         RadarrRoutes.MOVIE.go(params: {

--- a/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
@@ -151,10 +151,8 @@ class _RadarrAddMovieStreamingProvidersTileState
                         ),
                       ),
                     )
-                  : Wrap(
-                      alignment: WrapAlignment.start,
-                      spacing: 8,
-                      runSpacing: 8,
+                  : Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
                         ...visibleProviders
                             .where((provider) {
@@ -163,19 +161,22 @@ class _RadarrAddMovieStreamingProvidersTileState
                             })
                             .map((provider) {
                               final logoPath = provider['logo_path'] as String;
-                              return GestureDetector(
-                                onTap: () => _openProvider(provider),
-                                child: Tooltip(
-                                  message: provider['provider_name'] ?? '',
-                                  child: ClipRRect(
-                                    borderRadius: BorderRadius.circular(6),
-                                    child: Image.network(
-                                      TMDBApi.getImageUrl(logoPath, size: 'w92'),
-                                      width: 36,
-                                      height: 36,
-                                      fit: BoxFit.cover,
-                                      errorBuilder: (_, __, ___) =>
-                                          const SizedBox.shrink(),
+                              return Padding(
+                                padding: const EdgeInsets.only(right: 8),
+                                child: GestureDetector(
+                                  onTap: () => _openProvider(provider),
+                                  child: Tooltip(
+                                    message: provider['provider_name'] ?? '',
+                                    child: ClipRRect(
+                                      borderRadius: BorderRadius.circular(6),
+                                      child: Image.network(
+                                        TMDBApi.getImageUrl(logoPath, size: 'w92'),
+                                        width: 36,
+                                        height: 36,
+                                        fit: BoxFit.cover,
+                                        errorBuilder: (_, __, ___) =>
+                                            const SizedBox.shrink(),
+                                      ),
                                     ),
                                   ),
                                 ),

--- a/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/bottom_action_bar.dart
+++ b/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/bottom_action_bar.dart
@@ -48,7 +48,7 @@ class SonarrAddSeriesDetailsActionBar extends StatelessWidget {
         monitorType: _state.monitorType,
       )
           .then((series) async {
-        context.read<SonarrState>().fetchAllSeries();
+        await context.read<SonarrState>().fetchAllSeries();
         context.read<SonarrSeriesAddDetailsState>().series.id = series!.id;
 
         ZagRouter.router.pop();

--- a/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
@@ -160,10 +160,8 @@ class _SonarrAddSeriesStreamingProvidersTileState
                         ),
                       ),
                     )
-                  : Wrap(
-                      alignment: WrapAlignment.start,
-                      spacing: 8,
-                      runSpacing: 8,
+                  : Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
                         ...visibleProviders
                             .where((provider) {
@@ -172,19 +170,22 @@ class _SonarrAddSeriesStreamingProvidersTileState
                             })
                             .map((provider) {
                               final logoPath = provider['logo_path'] as String;
-                              return GestureDetector(
-                                onTap: () => _openProvider(provider),
-                                child: Tooltip(
-                                  message: provider['provider_name'] ?? '',
-                                  child: ClipRRect(
-                                    borderRadius: BorderRadius.circular(6),
-                                    child: Image.network(
-                                      TMDBApi.getImageUrl(logoPath, size: 'w92'),
-                                      width: 36,
-                                      height: 36,
-                                      fit: BoxFit.cover,
-                                      errorBuilder: (_, __, ___) =>
-                                          const SizedBox.shrink(),
+                              return Padding(
+                                padding: const EdgeInsets.only(right: 8),
+                                child: GestureDetector(
+                                  onTap: () => _openProvider(provider),
+                                  child: Tooltip(
+                                    message: provider['provider_name'] ?? '',
+                                    child: ClipRRect(
+                                      borderRadius: BorderRadius.circular(6),
+                                      child: Image.network(
+                                        TMDBApi.getImageUrl(logoPath, size: 'w92'),
+                                        width: 36,
+                                        height: 36,
+                                        fit: BoxFit.cover,
+                                        errorBuilder: (_, __, ___) =>
+                                            const SizedBox.shrink(),
+                                      ),
                                     ),
                                   ),
                                 ),


### PR DESCRIPTION
Fixed two issues:

1. Phantom cube appearing below streaming provider icons:
   - Changed from Wrap to Row widget since we only show a single row
   - The runSpacing in Wrap was creating phantom spacing below the icons
   - Applied fix to both movie and series streaming provider tiles

2. Race condition when navigating from add to details pages:
   - Added await to fetchMovies()/fetchAllSeries() calls before navigation
   - Ensures movie/series data is fully loaded before the details page loads
   - Prevents potential image loading failures on details pages