### PR TITLE
Revert await on void methods that caused build failure

### DIFF
--- a/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/bottom_action_bar.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/bottom_action_bar.dart
@@ -41,7 +41,7 @@ class RadarrAddMovieDetailsActionBar extends StatelessWidget {
         searchForMovie: RadarrDatabase.ADD_MOVIE_SEARCH_FOR_MISSING.read(),
       )
           .then((movie) async {
-        await context.read<RadarrState>().fetchMovies();
+        context.read<RadarrState>().fetchMovies();
         context.read<RadarrAddMovieDetailsState>().movie.id = movie!.id;
         ZagRouter.router.pop();
         RadarrRoutes.MOVIE.go(params: {

--- a/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/bottom_action_bar.dart
+++ b/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/bottom_action_bar.dart
@@ -48,7 +48,7 @@ class SonarrAddSeriesDetailsActionBar extends StatelessWidget {
         monitorType: _state.monitorType,
       )
           .then((series) async {
-        await context.read<SonarrState>().fetchAllSeries();
+        context.read<SonarrState>().fetchAllSeries();
         context.read<SonarrSeriesAddDetailsState>().series.id = series!.id;
 
         ZagRouter.router.pop();


### PR DESCRIPTION
fetchMovies() and fetchAllSeries() return void, not Future, so they cannot be awaited. Reverted to original behavior.