### PR TITLE
Remove overflow button from streaming providers

### DIFF
--- a/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
@@ -117,8 +117,6 @@ class _RadarrAddMovieStreamingProvidersTileState
     required bool hasError,
   }) {
     final visibleProviders = providers.take(_maxVisibleIcons).toList();
-    final hasMore = providers.length > _maxVisibleIcons;
-    final hiddenCount = providers.length - _maxVisibleIcons;
     final isEmpty = providers.isEmpty;
 
     return Column(
@@ -153,75 +151,37 @@ class _RadarrAddMovieStreamingProvidersTileState
                     )
                   : Row(
                       mainAxisSize: MainAxisSize.min,
-                      children: [
-                        ...visibleProviders
-                            .where((provider) {
-                              final logoPath = provider['logo_path'] as String?;
-                              return logoPath != null && logoPath.isNotEmpty;
-                            })
-                            .map((provider) {
-                              final logoPath = provider['logo_path'] as String;
-                              return Padding(
-                                padding: const EdgeInsets.only(right: 8),
-                                child: GestureDetector(
-                                  onTap: () => _openProvider(provider),
-                                  child: Tooltip(
-                                    message: provider['provider_name'] ?? '',
-                                    child: ClipRRect(
-                                      borderRadius: BorderRadius.circular(6),
-                                      child: Image.network(
-                                        TMDBApi.getImageUrl(logoPath, size: 'w92'),
-                                        width: 36,
-                                        height: 36,
-                                        fit: BoxFit.cover,
-                                        errorBuilder: (_, __, ___) =>
-                                            const SizedBox.shrink(),
-                                      ),
+                      children: visibleProviders
+                          .where((provider) {
+                            final logoPath = provider['logo_path'] as String?;
+                            return logoPath != null && logoPath.isNotEmpty;
+                          })
+                          .map((provider) {
+                            final logoPath = provider['logo_path'] as String;
+                            return Padding(
+                              padding: const EdgeInsets.only(right: 8),
+                              child: GestureDetector(
+                                onTap: () => _openProvider(provider),
+                                child: Tooltip(
+                                  message: provider['provider_name'] ?? '',
+                                  child: ClipRRect(
+                                    borderRadius: BorderRadius.circular(6),
+                                    child: Image.network(
+                                      TMDBApi.getImageUrl(logoPath, size: 'w92'),
+                                      width: 36,
+                                      height: 36,
+                                      fit: BoxFit.cover,
+                                      errorBuilder: (_, __, ___) =>
+                                          const SizedBox.shrink(),
                                     ),
                                   ),
                                 ),
-                              );
-                            }),
-                        if (hasMore)
-                          GestureDetector(
-                            onTap: () => _showAllProviders(title, providers),
-                            child: Container(
-                              width: 36,
-                              height: 36,
-                              decoration: BoxDecoration(
-                                color: Colors.grey.withValues(alpha: 0.2),
-                                borderRadius: BorderRadius.circular(6),
                               ),
-                              child: Center(
-                                child: Text(
-                                  '+$hiddenCount',
-                                  style: const TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                      ],
+                            );
+                          }).toList(),
                     ),
         ),
       ],
-    );
-  }
-
-  void _showAllProviders(String title, List<Map<String, dynamic>> providers) {
-    final providerNames = providers
-        .map((p) => p['provider_name'] as String?)
-        .where((name) => name != null && name.isNotEmpty)
-        .join(', ');
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('$title: $providerNames'),
-        duration: const Duration(seconds: 4),
-        behavior: SnackBarBehavior.floating,
-      ),
     );
   }
 

--- a/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
@@ -126,8 +126,6 @@ class _SonarrAddSeriesStreamingProvidersTileState
     required bool hasError,
   }) {
     final visibleProviders = providers.take(_maxVisibleIcons).toList();
-    final hasMore = providers.length > _maxVisibleIcons;
-    final hiddenCount = providers.length - _maxVisibleIcons;
     final isEmpty = providers.isEmpty;
 
     return Column(
@@ -162,75 +160,37 @@ class _SonarrAddSeriesStreamingProvidersTileState
                     )
                   : Row(
                       mainAxisSize: MainAxisSize.min,
-                      children: [
-                        ...visibleProviders
-                            .where((provider) {
-                              final logoPath = provider['logo_path'] as String?;
-                              return logoPath != null && logoPath.isNotEmpty;
-                            })
-                            .map((provider) {
-                              final logoPath = provider['logo_path'] as String;
-                              return Padding(
-                                padding: const EdgeInsets.only(right: 8),
-                                child: GestureDetector(
-                                  onTap: () => _openProvider(provider),
-                                  child: Tooltip(
-                                    message: provider['provider_name'] ?? '',
-                                    child: ClipRRect(
-                                      borderRadius: BorderRadius.circular(6),
-                                      child: Image.network(
-                                        TMDBApi.getImageUrl(logoPath, size: 'w92'),
-                                        width: 36,
-                                        height: 36,
-                                        fit: BoxFit.cover,
-                                        errorBuilder: (_, __, ___) =>
-                                            const SizedBox.shrink(),
-                                      ),
+                      children: visibleProviders
+                          .where((provider) {
+                            final logoPath = provider['logo_path'] as String?;
+                            return logoPath != null && logoPath.isNotEmpty;
+                          })
+                          .map((provider) {
+                            final logoPath = provider['logo_path'] as String;
+                            return Padding(
+                              padding: const EdgeInsets.only(right: 8),
+                              child: GestureDetector(
+                                onTap: () => _openProvider(provider),
+                                child: Tooltip(
+                                  message: provider['provider_name'] ?? '',
+                                  child: ClipRRect(
+                                    borderRadius: BorderRadius.circular(6),
+                                    child: Image.network(
+                                      TMDBApi.getImageUrl(logoPath, size: 'w92'),
+                                      width: 36,
+                                      height: 36,
+                                      fit: BoxFit.cover,
+                                      errorBuilder: (_, __, ___) =>
+                                          const SizedBox.shrink(),
                                     ),
                                   ),
                                 ),
-                              );
-                            }),
-                        if (hasMore)
-                          GestureDetector(
-                            onTap: () => _showAllProviders(title, providers),
-                            child: Container(
-                              width: 36,
-                              height: 36,
-                              decoration: BoxDecoration(
-                                color: Colors.grey.withValues(alpha: 0.2),
-                                borderRadius: BorderRadius.circular(6),
                               ),
-                              child: Center(
-                                child: Text(
-                                  '+$hiddenCount',
-                                  style: const TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                      ],
+                            );
+                          }).toList(),
                     ),
         ),
       ],
-    );
-  }
-
-  void _showAllProviders(String title, List<Map<String, dynamic>> providers) {
-    final providerNames = providers
-        .map((p) => p['provider_name'] as String?)
-        .where((name) => name != null && name.isNotEmpty)
-        .join(', ');
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('$title: $providerNames'),
-        duration: const Duration(seconds: 4),
-        behavior: SnackBarBehavior.floating,
-      ),
     );
   }
 


### PR DESCRIPTION
Removed the "+X" overflow button that appeared when there were more than 4 streaming providers. Now simply shows up to 4 provider icons with no overflow indicator.

Changes:
- Removed hasMore and hiddenCount variables
- Removed the overflow button widget
- Removed _showAllProviders method
- Applied to both movie and series streaming provider tiles