### PR TITLE
Make streaming providers responsive to screen width

### DIFF
--- a/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/radarr/routes/add_movie_details/widgets/tile_streaming_providers.dart
@@ -27,9 +27,6 @@ class _RadarrAddMovieStreamingProvidersTileState
   bool _hasError = false;
   late final bool _isPremium;
 
-  // Max icons per section (side by side layout)
-  static const int _maxVisibleIcons = 4;
-
   @override
   void initState() {
     super.initState();
@@ -116,7 +113,6 @@ class _RadarrAddMovieStreamingProvidersTileState
     required bool isLoading,
     required bool hasError,
   }) {
-    final visibleProviders = providers.take(_maxVisibleIcons).toList();
     final isEmpty = providers.isEmpty;
 
     return Column(
@@ -149,36 +145,52 @@ class _RadarrAddMovieStreamingProvidersTileState
                         ),
                       ),
                     )
-                  : Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: visibleProviders
-                          .where((provider) {
-                            final logoPath = provider['logo_path'] as String?;
-                            return logoPath != null && logoPath.isNotEmpty;
-                          })
-                          .map((provider) {
-                            final logoPath = provider['logo_path'] as String;
-                            return Padding(
-                              padding: const EdgeInsets.only(right: 8),
-                              child: GestureDetector(
-                                onTap: () => _openProvider(provider),
-                                child: Tooltip(
-                                  message: provider['provider_name'] ?? '',
-                                  child: ClipRRect(
-                                    borderRadius: BorderRadius.circular(6),
-                                    child: Image.network(
-                                      TMDBApi.getImageUrl(logoPath, size: 'w92'),
-                                      width: 36,
-                                      height: 36,
-                                      fit: BoxFit.cover,
-                                      errorBuilder: (_, __, ___) =>
-                                          const SizedBox.shrink(),
+                  : LayoutBuilder(
+                      builder: (context, constraints) {
+                        // Calculate how many icons can fit
+                        // Icon width: 36, spacing: 8
+                        const iconWidth = 36.0;
+                        const spacing = 8.0;
+                        final availableWidth = constraints.maxWidth;
+
+                        // Calculate max icons that fit
+                        int maxIcons = ((availableWidth + spacing) / (iconWidth + spacing)).floor();
+                        maxIcons = maxIcons.clamp(1, providers.length);
+
+                        final visibleProviders = providers.take(maxIcons).toList();
+
+                        return Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: visibleProviders
+                              .where((provider) {
+                                final logoPath = provider['logo_path'] as String?;
+                                return logoPath != null && logoPath.isNotEmpty;
+                              })
+                              .map((provider) {
+                                final logoPath = provider['logo_path'] as String;
+                                return Padding(
+                                  padding: const EdgeInsets.only(right: 8),
+                                  child: GestureDetector(
+                                    onTap: () => _openProvider(provider),
+                                    child: Tooltip(
+                                      message: provider['provider_name'] ?? '',
+                                      child: ClipRRect(
+                                        borderRadius: BorderRadius.circular(6),
+                                        child: Image.network(
+                                          TMDBApi.getImageUrl(logoPath, size: 'w92'),
+                                          width: 36,
+                                          height: 36,
+                                          fit: BoxFit.cover,
+                                          errorBuilder: (_, __, ___) =>
+                                              const SizedBox.shrink(),
+                                        ),
+                                      ),
                                     ),
                                   ),
-                                ),
-                              ),
-                            );
-                          }).toList(),
+                                );
+                              }).toList(),
+                        );
+                      },
                     ),
         ),
       ],

--- a/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
+++ b/zagreus/lib/modules/sonarr/routes/add_series_details/widgets/tile_streaming_providers.dart
@@ -27,9 +27,6 @@ class _SonarrAddSeriesStreamingProvidersTileState
   bool _hasError = false;
   late final bool _isPremium;
 
-  // Max icons per section (side by side layout)
-  static const int _maxVisibleIcons = 4;
-
   @override
   void initState() {
     super.initState();
@@ -125,7 +122,6 @@ class _SonarrAddSeriesStreamingProvidersTileState
     required bool isLoading,
     required bool hasError,
   }) {
-    final visibleProviders = providers.take(_maxVisibleIcons).toList();
     final isEmpty = providers.isEmpty;
 
     return Column(
@@ -158,36 +154,52 @@ class _SonarrAddSeriesStreamingProvidersTileState
                         ),
                       ),
                     )
-                  : Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: visibleProviders
-                          .where((provider) {
-                            final logoPath = provider['logo_path'] as String?;
-                            return logoPath != null && logoPath.isNotEmpty;
-                          })
-                          .map((provider) {
-                            final logoPath = provider['logo_path'] as String;
-                            return Padding(
-                              padding: const EdgeInsets.only(right: 8),
-                              child: GestureDetector(
-                                onTap: () => _openProvider(provider),
-                                child: Tooltip(
-                                  message: provider['provider_name'] ?? '',
-                                  child: ClipRRect(
-                                    borderRadius: BorderRadius.circular(6),
-                                    child: Image.network(
-                                      TMDBApi.getImageUrl(logoPath, size: 'w92'),
-                                      width: 36,
-                                      height: 36,
-                                      fit: BoxFit.cover,
-                                      errorBuilder: (_, __, ___) =>
-                                          const SizedBox.shrink(),
+                  : LayoutBuilder(
+                      builder: (context, constraints) {
+                        // Calculate how many icons can fit
+                        // Icon width: 36, spacing: 8
+                        const iconWidth = 36.0;
+                        const spacing = 8.0;
+                        final availableWidth = constraints.maxWidth;
+
+                        // Calculate max icons that fit
+                        int maxIcons = ((availableWidth + spacing) / (iconWidth + spacing)).floor();
+                        maxIcons = maxIcons.clamp(1, providers.length);
+
+                        final visibleProviders = providers.take(maxIcons).toList();
+
+                        return Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: visibleProviders
+                              .where((provider) {
+                                final logoPath = provider['logo_path'] as String?;
+                                return logoPath != null && logoPath.isNotEmpty;
+                              })
+                              .map((provider) {
+                                final logoPath = provider['logo_path'] as String;
+                                return Padding(
+                                  padding: const EdgeInsets.only(right: 8),
+                                  child: GestureDetector(
+                                    onTap: () => _openProvider(provider),
+                                    child: Tooltip(
+                                      message: provider['provider_name'] ?? '',
+                                      child: ClipRRect(
+                                        borderRadius: BorderRadius.circular(6),
+                                        child: Image.network(
+                                          TMDBApi.getImageUrl(logoPath, size: 'w92'),
+                                          width: 36,
+                                          height: 36,
+                                          fit: BoxFit.cover,
+                                          errorBuilder: (_, __, ___) =>
+                                              const SizedBox.shrink(),
+                                        ),
+                                      ),
                                     ),
                                   ),
-                                ),
-                              ),
-                            );
-                          }).toList(),
+                                );
+                              }).toList(),
+                        );
+                      },
                     ),
         ),
       ],


### PR DESCRIPTION
Changed from fixed 4-icon limit to dynamically calculating how many provider icons can fit based on available screen width.

Uses LayoutBuilder to measure available space and calculates:
- Icon width: 36px
- Spacing: 8px
- Max icons = floor((availableWidth + spacing) / (iconWidth + spacing))

This ensures optimal use of screen space on all device sizes while keeping both sections (Streaming On / Buy/Rent On) balanced since they use the same calculation.