### PR TITLE
Show locked pro modules in Settings -> Configuration

### DIFF
--- a/zagreus/lib/modules/settings/routes/configuration/route.dart
+++ b/zagreus/lib/modules/settings/routes/configuration/route.dart
@@ -124,20 +124,9 @@ class _State extends State<ConfigurationRoute> with ZagScrollControllerMixin {
   }
 
   List<Widget> _moduleList() {
-    final bool isPro = ZagreusPro.isEnabled;
     final modules = [ZagModule.DASHBOARD, ...ZagModule.active]
         .where((module) => module.settingsRoute != null)
         .toList();
-
-    // Remove Pro-locked modules if user doesn't have Pro
-    if (!isPro) {
-      modules.removeWhere(
-        (module) =>
-            module == ZagModule.DISCOVER ||
-            module == ZagModule.OVERSEERR ||
-            module == ZagModule.UNRAID,
-      );
-    }
 
     // Remove Discover module (redundant - settings moved elsewhere)
     modules.removeWhere(
@@ -151,18 +140,29 @@ class _State extends State<ConfigurationRoute> with ZagScrollControllerMixin {
     return modules.map(_tileFromModuleMap).toList();
   }
 
+  bool _isProModule(ZagModule module) {
+    return module == ZagModule.OVERSEERR || module == ZagModule.UNRAID;
+  }
+
   Widget _tileFromModuleMap(ZagModule module) {
+    final bool isPro = ZagreusPro.isEnabled;
+    final bool isLocked = _isProModule(module) && !isPro;
+
     return ZagBlock(
       title: module.title,
       body: [
         TextSpan(
-          text: 'settings.ConfigureModule'.tr(args: [module.title])
+          text: isLocked
+            ? 'Requires Zagreus Pro'
+            : 'settings.ConfigureModule'.tr(args: [module.title])
         )
       ],
       trailing: ZagIconButton(
-        icon: module.icon,
+        icon: isLocked ? Icons.lock_rounded : module.icon,
       ),
-      onTap: module.settingsRoute!.go,
+      onTap: isLocked
+        ? () => _showProPurchaseDialog(context)
+        : module.settingsRoute!.go,
     );
   }
   


### PR DESCRIPTION
Previously, Unraid and Overseerr modules were hidden from the module list when users didn't have Pro, causing confusion about their existence.

Changes:
- Pro-only modules (Unraid, Overseerr) now display in the module list with a lock icon
- Locked modules show "Requires Zagreus Pro" description
- Tapping locked modules opens the Pro purchase dialog
- Non-pro users can now discover pro features without needing to search elsewhere