### PR TITLE
Fix calendar events list not updating when date is selected

### DIFF
--- a/zagreus/lib/modules/dashboard/routes/dashboard/widgets/calendar_view.dart
+++ b/zagreus/lib/modules/dashboard/routes/dashboard/widgets/calendar_view.dart
@@ -54,7 +54,10 @@ class _State extends State<CalendarView> {
         children: [
           _calendar(),
           ZagDivider(),
-          _calendarList(),
+          Selector<DashboardState, DateTime>(
+            selector: (_, state) => state.selected,
+            builder: (context, selected, _) => _calendarList(selected),
+          ),
         ],
       ),
       padding: EdgeInsets.only(top: ZagUI.MARGIN_H_DEFAULT_V_HALF.top),
@@ -225,8 +228,7 @@ class _State extends State<CalendarView> {
     return counter;
   }
 
-  Widget _calendarList() {
-    final selected = context.read<DashboardState>().selected;
+  Widget _calendarList(DateTime selected) {
     final events = widget.events[selected.floor()] ?? [];
     if (events.isEmpty) {
       return Expanded(


### PR DESCRIPTION
The events list below the calendar was not updating when users clicked a different date because it was using context.read() instead of watching for state changes.

Wrapped the calendar list in a Selector that watches the selected date, so now the events list automatically updates when a date is clicked without needing to pull-to-refresh.