### PR TITLE
Hide auto-updates weekly message for Pro users

### DIFF
--- a/zagreus/lib/modules/discover/routes/discover/route.dart
+++ b/zagreus/lib/modules/discover/routes/discover/route.dart
@@ -3021,6 +3021,12 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
   }
 
   Widget _zAutoRefreshNote() {
+    // Only show for Mega and Ultra users (not Pro)
+    final isMegaOrUltra = ZagreusMega.isEnabled || ZagreusUltra.isEnabled;
+    if (!isMegaOrUltra) {
+      return const SizedBox.shrink();
+    }
+
     final textColor = Theme.of(context)
         .textTheme
         .bodySmall


### PR DESCRIPTION
The weekly auto-update message at the bottom of the Discover section
is now only shown to Mega and Ultra tier users, as Pro users don't
have access to the weekly updating sections.