### PR TITLE
Replace close icon with back icon in search bar

### DIFF
--- a/lib/modules/discover/routes/discover/route.dart
+++ b/lib/modules/discover/routes/discover/route.dart
@@ -2216,8 +2216,8 @@ class _State extends State<DiscoverHomeRoute> with ZagScrollControllerMixin {
       return [
         IconButton(
           key: const ValueKey('discover_action_close_search'),
-          icon: const Icon(Icons.close_rounded),
-          tooltip: 'Close Search',
+          icon: const Icon(Icons.arrow_back),
+          tooltip: 'Back',
           onPressed: _closeSearchOverlay,
         ),
       ];


### PR DESCRIPTION
Changed the X (close) icon to a back arrow icon in the discover search app bar to avoid confusion with the X icon in the search input field.