### PR TITLE
Fix overlapping GB labels in discover server

### DIFF
--- a/lib/modules/unraid/routes/unraid/widgets/download_history_card.dart
+++ b/lib/modules/unraid/routes/unraid/widgets/download_history_card.dart
@@ -148,7 +148,8 @@ class DownloadHistoryCard extends StatelessWidget {
             leftTitles: AxisTitles(
               sideTitles: SideTitles(
                 showTitles: true,
-                reservedSize: 36, // Less space
+                reservedSize: 40, // Slightly more space for labels
+                interval: maxValue > 0 ? maxValue / 2 : 1, // Show only 2 labels to prevent overlap
                 getTitlesWidget: (value, meta) {
                   if (value == 0) return const Text('');
                   return Text(


### PR DESCRIPTION
Reduced Y-axis label density by changing interval from maxValue/3 to maxValue/2, displaying only 2 labels instead of 3. Also increased reservedSize from 36 to 40 pixels to provide more horizontal space for label text. This prevents vertical overlap of GB labels while maintaining grid lines for visual reference.