### PR TITLE
Remove Pro Monthly subscription option from dialog

### DIFF
--- a/lib/modules/settings/routes/subscriptions/route.dart
+++ b/lib/modules/settings/routes/subscriptions/route.dart
@@ -456,7 +456,7 @@ class _State extends State<SubscriptionsRoute> with ZagScrollControllerMixin {
           ],
           if (!isPro || isMega || isUltra || isSupreme) ...[
             ZagDialog.tile(
-              icon: Icons.stars_rounded,
+              icon: Icons.rocket_launch_rounded,
               iconColor: ZagColours.currentAccent,
               text: 'settings.SubscriptionsPlanYearly'
                   .tr(args: ['\$4.99/year']),


### PR DESCRIPTION
Remove the $0.99/month Pro subscription tile from the purchase
dialog, keeping only Yearly and Lifetime options for new subscribers.